### PR TITLE
Fix round maximized newly openned windows 

### DIFF
--- a/shapecorners.cpp
+++ b/shapecorners.cpp
@@ -70,7 +70,6 @@ ShapeCornersEffect::ShapeCornersEffect() : KWin::Effect(), m_shader(nullptr)
 //        qDebug() << "shader valid: " << m_shader->isValid();
         if (m_shader->isValid())
         {
-            applyEffect = NULL;
             const int sampler = m_shader->uniformLocation("sampler");
             const int corner = m_shader->uniformLocation("corner");
             KWin::ShaderManager::instance()->pushShader(m_shader);
@@ -92,13 +91,6 @@ ShapeCornersEffect::ShapeCornersEffect() : KWin::Effect(), m_shader(nullptr)
         qDebug() << "ShapeCorners: no shaders found! Exiting...";
         deleteLater();
     }
-}
-
-void ShapeCornersEffect::windowMaximizedStateChanged(KWin::EffectWindow *w, bool horizontal, bool vertical) {
-    if ((horizontal == true) && (vertical == true))
-        applyEffect = w;
-    else
-        applyEffect = NULL;
 }
 
 ShapeCornersEffect::~ShapeCornersEffect()
@@ -216,7 +208,6 @@ ShapeCornersEffect::prePaintWindow(KWin::EffectWindow *w, KWin::WindowPrePaintDa
 //            || KWin::effects->hasActiveFullScreenEffect()
             || w->isDesktop()
             || isMaximized(w)
-            || (w == applyEffect)
 #if KWIN_EFFECT_API_VERSION < 233
            || data.quads.isTransformed()
 #endif
@@ -264,7 +255,6 @@ ShapeCornersEffect::paintWindow(KWin::EffectWindow *w, int mask, QRegion region,
 //            || KWin::effects->hasActiveFullScreenEffect()
             || w->isDesktop()
             || isMaximized(w)
-            || (w == applyEffect)
 #if KWIN_EFFECT_API_VERSION < 233
             || data.quads.isTransformed()
             || !hasShadow(data.quads)
@@ -402,6 +392,12 @@ ShapeCornersEffect::enabledByDefault()
 bool ShapeCornersEffect::supported()
 {
     return KWin::effects->isOpenGLCompositing() && KWin::GLRenderTarget::supported();
+}
+
+bool ShapeCornersEffect::isMaximized(KWin::EffectWindow *w) {
+    auto screenGeometry = KWin::effects->screens().at(w->screen())->geometry();
+    return (w->x() == screenGeometry.x() && w->width() == screenGeometry.width()) ||
+            (w->y() == screenGeometry.y() && w->height() == screenGeometry.height());
 }
 
 #include "shapecorners.moc"

--- a/shapecorners.cpp
+++ b/shapecorners.cpp
@@ -401,9 +401,13 @@ bool ShapeCornersEffect::supported()
 }
 
 bool ShapeCornersEffect::isMaximized(KWin::EffectWindow *w) {
+#if KWIN_EFFECT_API_VERSION < 233
+    return w->isFullScreen();
+#else
     auto screenGeometry = KWin::effects->findScreen(w->screen()->name())->geometry();
     return (w->x() == screenGeometry.x() && w->width() == screenGeometry.width()) ||
             (w->y() == screenGeometry.y() && w->height() == screenGeometry.height());
+#endif
 }
 
 #include "shapecorners.moc"

--- a/shapecorners.cpp
+++ b/shapecorners.cpp
@@ -81,7 +81,6 @@ ShapeCornersEffect::ShapeCornersEffect() : KWin::Effect(), m_shader(nullptr)
                     windowAdded(win);
             connect(KWin::effects, &KWin::EffectsHandler::windowAdded, this, &ShapeCornersEffect::windowAdded);
             connect(KWin::effects, &KWin::EffectsHandler::windowClosed, this, [this](){m_managed.removeOne(dynamic_cast<KWin::EffectWindow *>(sender()));});
-            connect(KWin::effects, &KWin::EffectsHandler::windowMaximizedStateChanged, this, &ShapeCornersEffect::windowMaximizedStateChanged);
         }
         else
             qDebug() << "ShapeCorners: no valid shaders found! ShapeCorners will not work.";

--- a/shapecorners.h
+++ b/shapecorners.h
@@ -47,7 +47,6 @@ public:
     void prePaintWindow(KWin::EffectWindow* w, KWin::WindowPrePaintData& data, int time);
 #endif
     void paintWindow(KWin::EffectWindow* w, int mask, QRegion region, KWin::WindowPaintData& data);
-    void windowMaximizedStateChanged(KWin::EffectWindow *w, bool horizontal, bool vertical);
     virtual int requestedEffectChainPosition() const { return 99; }
 
 protected Q_SLOTS:

--- a/shapecorners.h
+++ b/shapecorners.h
@@ -33,12 +33,12 @@ public:
 
     static bool supported();
     static bool enabledByDefault();
+    static bool isMaximized(KWin::EffectWindow *w);
+    static void fillRegion(const QRegion &reg, const QColor &c);
 
     void setRoundness(const int r);
     void genMasks();
     void genRect();
-
-    void fillRegion(const QRegion &reg, const QColor &c);
 
     void reconfigure(ReconfigureFlags flags);
 #if KWIN_EFFECT_API_VERSION > 230
@@ -60,7 +60,6 @@ private:
     int m_size, m_rSize, m_alpha;
     QSize m_corner;
     QRegion m_updateRegion;
-    KWin::EffectWindow *applyEffect;
     KWin::GLShader *m_shader;
     QList<KWin::EffectWindow *> m_managed;
 };


### PR DESCRIPTION
This pull request is closing issue #3. I removed the maximized event and implemented an isMaximized query that can be called as necessary. It also works with edge snaps (either horizontal or vertical).