### PR TITLE
Draw fake shadows using shaders

### DIFF
--- a/shaders_110/shapecorners.frag
+++ b/shaders_110/shapecorners.frag
@@ -3,7 +3,7 @@
 uniform sampler2D sampler;
 uniform int cornerIndex;
 uniform bool windowActive;
-uniform bool drawShadow;
+uniform vec4 shadowColor;
 
 varying vec2 texcoord0;
 
@@ -16,21 +16,21 @@ vec4 shadowCorner(float distance_from_center, vec4 backColor, bool isTopCorner) 
     if (windowActive) {
         if (isTopCorner) {
             float percent = (distance_from_center + 0.15) / (sqrt(2)+0.2);
-            return goTowards(vec4(0, 0, 0, 1), backColor, percent);
+            return goTowards(shadowColor, backColor, percent);
         }
         else {
             float percent = (distance_from_center - 0.25) / (sqrt(2)+0.1);
-            return goTowards(vec4(0, 0, 0, 1), backColor, percent);
+            return goTowards(shadowColor, backColor, percent);
         }
     }
     else {
         if (isTopCorner) {
             float percent = (distance_from_center + 0.55) / (sqrt(2)+0.5);
-            return goTowards(vec4(0, 0, 0, 1), backColor, percent);
+            return goTowards(shadowColor, backColor, percent);
         }
         else {
             float percent = (distance_from_center) / (sqrt(2)+0.1);
-            return goTowards(vec4(0, 0, 0, 1), backColor, percent);
+            return goTowards(shadowColor, backColor, percent);
         }
     }
 }
@@ -40,10 +40,10 @@ vec4 shapeCorner(vec2 texcoord0, vec4 backColor, vec2 center, bool isTopCorner) 
     if(distance_from_center < 1)
     backColor.a = 0;
     else {
-        if(drawShadow)
-        backColor = shadowCorner(distance_from_center, backColor, isTopCorner);
+        if(shadowColor.a > 0)
+            backColor = shadowCorner(distance_from_center, backColor, isTopCorner);
         else
-        backColor.a = 1;
+            backColor.a = 1;
     }
     return backColor;
 }

--- a/shaders_110/shapecorners.frag
+++ b/shaders_110/shapecorners.frag
@@ -1,14 +1,63 @@
 #version 110
 
 uniform sampler2D sampler;
-uniform sampler2D corner;
+uniform int cornerIndex;
+uniform bool windowActive;
+uniform bool drawShadow;
 
 varying vec2 texcoord0;
 
+vec4 goTowards(vec4 fromColor, vec4 toColor, float percent) {
+    vec4 d = toColor - fromColor;
+    return d * percent + fromColor;
+}
+
+vec4 shadowCorner(float distance_from_center, vec4 backColor, bool isTopCorner) {
+    if (windowActive) {
+        if (isTopCorner) {
+            float percent = (distance_from_center + 0.15) / (sqrt(2)+0.2);
+            return goTowards(vec4(0, 0, 0, 1), backColor, percent);
+        }
+        else {
+            float percent = (distance_from_center - 0.25) / (sqrt(2)+0.1);
+            return goTowards(vec4(0, 0, 0, 1), backColor, percent);
+        }
+    }
+    else {
+        if (isTopCorner) {
+            float percent = (distance_from_center + 0.55) / (sqrt(2)+0.5);
+            return goTowards(vec4(0, 0, 0, 1), backColor, percent);
+        }
+        else {
+            float percent = (distance_from_center) / (sqrt(2)+0.1);
+            return goTowards(vec4(0, 0, 0, 1), backColor, percent);
+        }
+    }
+}
+
+vec4 shapeCorner(vec2 texcoord0, vec4 backColor, vec2 center, bool isTopCorner) {
+    float distance_from_center = distance(texcoord0, center);
+    if(distance_from_center < 1)
+    backColor.a = 0;
+    else {
+        if(drawShadow)
+        backColor = shadowCorner(distance_from_center, backColor, isTopCorner);
+        else
+        backColor.a = 1;
+    }
+    return backColor;
+}
+
 void main()
 {
-    vec4 tex = texture2D(sampler, texcoord0);
-    vec4 texCorner = texture2D(corner, texcoord0);
-    tex.a = texCorner.a;
-    gl_FragColor = tex;
+    vec4 tex = texture(sampler, texcoord0);
+    if(cornerIndex == 0)
+    tex = shapeCorner(texcoord0, tex, vec2(1, 0), true);
+    else if(cornerIndex == 1)
+    tex = shapeCorner(texcoord0, tex, vec2(0, 0), true);
+    else if(cornerIndex == 2)
+    tex = shapeCorner(texcoord0, tex, vec2(0, 1), false);
+    else if(cornerIndex == 3)
+    tex = shapeCorner(texcoord0, tex, vec2(1, 1), false);
+    fragColor = tex;
 }

--- a/shaders_140/shapecorners.frag
+++ b/shaders_140/shapecorners.frag
@@ -3,7 +3,7 @@
 uniform sampler2D sampler;
 uniform int cornerIndex;
 uniform bool windowActive;
-uniform bool drawShadow;
+uniform vec4 shadowColor;
 
 in vec2 texcoord0;
 out vec4 fragColor;
@@ -17,21 +17,21 @@ vec4 shadowCorner(float distance_from_center, vec4 backColor, bool isTopCorner) 
     if (windowActive) {
         if (isTopCorner) {
             float percent = (distance_from_center + 0.15) / (sqrt(2)+0.2);
-            return goTowards(vec4(0, 0, 0, 1), backColor, percent);
+            return goTowards(shadowColor, backColor, percent);
         }
         else {
             float percent = (distance_from_center - 0.25) / (sqrt(2)+0.1);
-            return goTowards(vec4(0, 0, 0, 1), backColor, percent);
+            return goTowards(shadowColor, backColor, percent);
         }
     }
     else {
         if (isTopCorner) {
             float percent = (distance_from_center + 0.55) / (sqrt(2)+0.5);
-            return goTowards(vec4(0, 0, 0, 1), backColor, percent);
+            return goTowards(shadowColor, backColor, percent);
         }
         else {
             float percent = (distance_from_center) / (sqrt(2)+0.1);
-            return goTowards(vec4(0, 0, 0, 1), backColor, percent);
+            return goTowards(shadowColor, backColor, percent);
         }
     }
 }
@@ -41,7 +41,7 @@ vec4 shapeCorner(vec2 texcoord0, vec4 backColor, vec2 center, bool isTopCorner) 
     if(distance_from_center < 1)
         backColor.a = 0;
     else {
-        if(drawShadow)
+        if(shadowColor.a > 0)
             backColor = shadowCorner(distance_from_center, backColor, isTopCorner);
         else
             backColor.a = 1;

--- a/shaders_140/shapecorners.frag
+++ b/shaders_140/shapecorners.frag
@@ -1,15 +1,64 @@
 #version 140
 
 uniform sampler2D sampler;
-uniform sampler2D corner;
+uniform int cornerIndex;
+uniform bool windowActive;
+uniform bool drawShadow;
 
 in vec2 texcoord0;
 out vec4 fragColor;
 
+vec4 goTowards(vec4 fromColor, vec4 toColor, float percent) {
+    vec4 d = toColor - fromColor;
+    return d * percent + fromColor;
+}
+
+vec4 shadowCorner(float distance_from_center, vec4 backColor, bool isTopCorner) {
+    if (windowActive) {
+        if (isTopCorner) {
+            float percent = (distance_from_center + 0.15) / (sqrt(2)+0.2);
+            return goTowards(vec4(0, 0, 0, 1), backColor, percent);
+        }
+        else {
+            float percent = (distance_from_center - 0.25) / (sqrt(2)+0.1);
+            return goTowards(vec4(0, 0, 0, 1), backColor, percent);
+        }
+    }
+    else {
+        if (isTopCorner) {
+            float percent = (distance_from_center + 0.55) / (sqrt(2)+0.5);
+            return goTowards(vec4(0, 0, 0, 1), backColor, percent);
+        }
+        else {
+            float percent = (distance_from_center) / (sqrt(2)+0.1);
+            return goTowards(vec4(0, 0, 0, 1), backColor, percent);
+        }
+    }
+}
+
+vec4 shapeCorner(vec2 texcoord0, vec4 backColor, vec2 center, bool isTopCorner) {
+    float distance_from_center = distance(texcoord0, center);
+    if(distance_from_center < 1)
+        backColor.a = 0;
+    else {
+        if(drawShadow)
+            backColor = shadowCorner(distance_from_center, backColor, isTopCorner);
+        else
+            backColor.a = 1;
+    }
+    return backColor;
+}
+
 void main(void)
 {
     vec4 tex = texture(sampler, texcoord0);
-    vec4 texCorner = texture(corner, texcoord0);
-    tex.a = texCorner.a;
+    if(cornerIndex == 0)
+        tex = shapeCorner(texcoord0, tex, vec2(1, 0), true);
+    else if(cornerIndex == 1)
+        tex = shapeCorner(texcoord0, tex, vec2(0, 0), true);
+    else if(cornerIndex == 2)
+        tex = shapeCorner(texcoord0, tex, vec2(0, 1), false);
+    else if(cornerIndex == 3)
+        tex = shapeCorner(texcoord0, tex, vec2(1, 1), false);
     fragColor = tex;
 }

--- a/shapecorners.cpp
+++ b/shapecorners.cpp
@@ -109,9 +109,11 @@ ShapeCornersEffect::windowAdded(KWin::EffectWindow *w)
             || w->windowType() == NET::WindowType::Dock)
         return;
 //    qDebug() << w->windowRole() << w->windowType() << w->windowClass();
-    if (!w->hasDecoration() && (w->windowClass().contains("plasma", Qt::CaseInsensitive)
-            || w->windowClass().contains("krunner", Qt::CaseInsensitive)
-            || w->windowClass().contains("latte-dock", Qt::CaseInsensitive)))
+//    if (!w->hasDecoration() && (w->windowClass().contains("plasma", Qt::CaseInsensitive)
+//            || w->windowClass().contains("krunner", Qt::CaseInsensitive)
+//            || w->windowClass().contains("latte-dock", Qt::CaseInsensitive)))
+//        return;
+    if (!w->hasDecoration())
         return;
     m_managed << w;
 }

--- a/shapecorners.cpp
+++ b/shapecorners.cpp
@@ -49,11 +49,6 @@ ShapeCornersEffect::ShapeCornersEffect() : KWin::Effect(), m_shader(nullptr)
 {
     new KWin::EffectAdaptor(this);
     QDBusConnection::sessionBus().registerObject("/ShapeCorners", this);
-    for (int i = 0; i < NTex; ++i)
-    {
-        m_tex[i] = nullptr;
-        m_rect[i] = nullptr;
-    }
     reconfigure(ReconfigureAll);
 
     QString shadersDir(QStringLiteral("kwin/shaders/1.10/"));
@@ -104,14 +99,7 @@ ShapeCornersEffect::ShapeCornersEffect() : KWin::Effect(), m_shader(nullptr)
     }
 }
 
-ShapeCornersEffect::~ShapeCornersEffect()
-{
-    for (int i = 0; i < NTex; ++i)
-    {
-        delete m_tex[i];
-        delete m_rect[i];
-    }
-}
+ShapeCornersEffect::~ShapeCornersEffect() = default;
 
 void
 ShapeCornersEffect::windowAdded(KWin::EffectWindow *w)
@@ -129,79 +117,18 @@ ShapeCornersEffect::windowAdded(KWin::EffectWindow *w)
 }
 
 void
-ShapeCornersEffect::genMasks()
-{
-    for (int i = 0; i < NTex; ++i)
-        delete m_tex[i];
-
-    QImage img(m_size*2, m_size*2, QImage::Format_ARGB32_Premultiplied);
-    img.fill(Qt::transparent);
-    QPainter p(&img);
-    p.fillRect(img.rect(), Qt::black);
-    p.setCompositionMode(QPainter::CompositionMode_DestinationOut);
-    p.setPen(Qt::NoPen);
-    p.setBrush(Qt::black);
-    p.setRenderHint(QPainter::Antialiasing);
-    p.drawEllipse(img.rect());
-    p.end();
-
-    m_tex[TopLeft] = new KWin::GLTexture(img.copy(0, 0, m_size, m_size));
-    m_tex[TopRight] = new KWin::GLTexture(img.copy(m_size, 0, m_size, m_size));
-    m_tex[BottomRight] = new KWin::GLTexture(img.copy(m_size, m_size, m_size, m_size));
-    m_tex[BottomLeft] = new KWin::GLTexture(img.copy(0, m_size, m_size, m_size));
-}
-
-void
-ShapeCornersEffect::genRect()
-{
-    for (int i = 0; i < NTex; ++i)
-        delete m_rect[i];
-
-    m_rSize = m_size+1;
-    QImage img(m_rSize*2, m_rSize*2, QImage::Format_ARGB32_Premultiplied);
-    img.fill(Qt::transparent);
-    QPainter p(&img);
-    QRect r(img.rect());
-    p.setPen(Qt::NoPen);
-    p.setBrush(QColor(0, 0, 0, m_alpha));
-    p.setRenderHint(QPainter::Antialiasing);
-    p.drawEllipse(r);
-    p.setCompositionMode(QPainter::CompositionMode_DestinationOut);
-    p.setBrush(Qt::black);
-    r.adjust(1, 1, -1, -1);
-    p.drawEllipse(r);
-    p.setCompositionMode(QPainter::CompositionMode_SourceOver);
-    p.setBrush(QColor(255, 255, 255, 63));
-    p.drawEllipse(r);
-    p.setCompositionMode(QPainter::CompositionMode_DestinationOut);
-    p.setBrush(Qt::black);
-    r.adjust(0, 1, 0, 0);
-    p.drawEllipse(r);
-    p.end();
-
-    m_rect[TopLeft] = new KWin::GLTexture(img.copy(0, 0, m_rSize, m_rSize));
-    m_rect[TopRight] = new KWin::GLTexture(img.copy(m_rSize, 0, m_rSize, m_rSize));
-    m_rect[BottomRight] = new KWin::GLTexture(img.copy(m_rSize, m_rSize, m_rSize, m_rSize));
-    m_rect[BottomLeft] = new KWin::GLTexture(img.copy(0, m_rSize, m_rSize, m_rSize));
-}
-
-void
 ShapeCornersEffect::setRoundness(const int r)
 {
-    m_alpha = 0xff;
     m_size = r;
-    m_corner = QSize(m_size, m_size);
-    genMasks();
-    genRect();
 }
 
 void
 ShapeCornersEffect::reconfigure(ReconfigureFlags flags)
 {
     Q_UNUSED(flags)
-    m_alpha = 63;
     KConfigGroup conf = KSharedConfig::openConfig("shapecorners.conf")->group("General");
     setRoundness(conf.readEntry("roundness", 5));
+    m_drawShadow = conf.readEntry("drawShadow", true);
 }
 
 #if KWIN_EFFECT_API_VERSION > 231
@@ -321,82 +248,29 @@ ShapeCornersEffect::paintWindow(KWin::EffectWindow *w, int mask, QRegion region,
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     const int mvpMatrixLocation = m_shader->uniformLocation("modelViewProjectionMatrix");
+    const int cornerIndexLocation = m_shader->uniformLocation("cornerIndex");
+    const int windowActiveLocation = m_shader->uniformLocation("windowActive");
+    const int drawShadowLocation = m_shader->uniformLocation("drawShadow");
     KWin::ShaderManager *sm = KWin::ShaderManager::instance();
     sm->pushShader(m_shader.get());
-    for (int i = 0; i < NTex; ++i)
     {
-        QMatrix4x4 mvp = data.screenProjectionMatrix();
-        mvp.translate(rect[i].x(), rect[i].y());
-        m_shader->setUniform(mvpMatrixLocation, mvp);
-        glActiveTexture(GL_TEXTURE1);
-        m_tex[3-i]->bind();
-        glActiveTexture(GL_TEXTURE0);
-        tex[i].bind();
-        tex[i].render(region, rect[i]);
-        tex[i].unbind();
-        m_tex[3-i]->unbind();
+        m_shader->setUniform(windowActiveLocation, KWin::effects->activeWindow() == w);
+        m_shader->setUniform(drawShadowLocation, m_drawShadow);
+        for (int i = 0; i < NTex; ++i) {
+            QMatrix4x4 mvp = data.screenProjectionMatrix();
+            mvp.translate(rect[i].x(), rect[i].y());
+            m_shader->setUniform(mvpMatrixLocation, mvp);
+            m_shader->setUniform(cornerIndexLocation, i);
+            tex[i].bind();
+            tex[i].render(region, rect[i]);
+            tex[i].unbind();
+        }
     }
     sm->popShader();
 #if KWIN_EFFECT_API_VERSION < 233
     data.quads = qds;
 #endif
-#if 0
-    if (data.brightness() == 1.0 && data.crossFadeProgress() == 1.0)
-    {
-        const QRect rrect[NTex] =
-        {
-            rect[0].adjusted(-1, -1, 0, 0),
-            rect[1].adjusted(0, -1, 1, 0),
-            rect[2].adjusted(0, 0, 1, 1),
-            rect[3].adjusted(-1, 0, 0, 1)
-        };
-        const float o(data.opacity());
-        KWin::GLShader *shader = KWin::ShaderManager::instance()->pushShader(KWin::ShaderTrait::MapTexture|KWin::ShaderTrait::UniformColor|KWin::ShaderTrait::Modulate);
-        shader->setUniform(KWin::GLShader::ModulationConstant, QVector4D(o, o, o, o));
-        glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
-        for (int i = 0; i < NTex; ++i)
-        {
-            QMatrix4x4 modelViewProjection;
-            modelViewProjection.ortho(0, s.width(), s.height(), 0, 0, 65535);
-            modelViewProjection.translate(rrect[i].x(), rrect[i].y());
-            shader->setUniform("modelViewProjectionMatrix", modelViewProjection);
-            m_rect[i]->bind();
-            m_rect[i]->render(region, rrect[i]);
-            m_rect[i]->unbind();
-        }
-//        KWin::ShaderManager::instance()->popShader();
-//        shader = KWin::ShaderManager::instance()->pushShader(KWin::ShaderTrait::UniformColor);
-        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-        QRegion reg = QRegion(geo.adjusted(-1, -1, 1, 1)) - geo;
-        for (int i = 0; i < 4; ++i)
-            reg -= rrect[i];
-        fillRegion(reg, QColor(0, 0, 0, m_alpha*data.opacity()));
-        fillRegion(QRegion(geo.x()+m_size, geo.y(), geo.width()-m_size*2, 1), QColor(255, 255, 255, m_alpha*data.opacity()));
-        KWin::ShaderManager::instance()->popShader();
-    }
-#endif
     glDisable(GL_BLEND);
-}
-
-void
-ShapeCornersEffect::fillRegion(const QRegion &reg, const QColor &c)
-{
-    KWin::GLVertexBuffer *vbo = KWin::GLVertexBuffer::streamingBuffer();
-    vbo->reset();
-    vbo->setUseColor(true);
-    vbo->setColor(c);
-    QVector<float> verts;
-    for (const QRect & r: reg)
-    {
-        verts << r.x() + r.width() << r.y();
-        verts << r.x() << r.y();
-        verts << r.x() << r.y() + r.height();
-        verts << r.x() << r.y() + r.height();
-        verts << r.x() + r.width() << r.y() + r.height();
-        verts << r.x() + r.width() << r.y();
-    }
-    vbo->setData(verts.count() / 2, 2, verts.data(), nullptr);
-    vbo->render(GL_TRIANGLES);
 }
 
 bool

--- a/shapecorners.h
+++ b/shapecorners.h
@@ -54,9 +54,12 @@ private:
     enum { TopLeft = 0, TopRight, BottomRight, BottomLeft, NTex };
     int m_size;
     bool m_drawShadow;
-    QRegion m_updateRegion;
-    std::unique_ptr<KWin::GLShader> m_shader;
     QList<KWin::EffectWindow *> m_managed;
+
+    std::unique_ptr<KWin::GLShader> m_shader;
+    int m_shader_cornerIndex = 0;
+    int m_shader_windowActive = 0;
+    int m_shader_drawShadow = 0;
 };
 
 #endif //SHAPECORNERS_H

--- a/shapecorners.h
+++ b/shapecorners.h
@@ -33,7 +33,7 @@ public:
     ~ShapeCornersEffect() override;
 
     static bool supported();
-    static bool enabledByDefault();
+    static bool enabledByDefault() { return supported(); }
     static bool isMaximized(KWin::EffectWindow *w);
 
     void setRoundness(int r);

--- a/shapecorners.h
+++ b/shapecorners.h
@@ -35,11 +35,8 @@ public:
     static bool supported();
     static bool enabledByDefault();
     static bool isMaximized(KWin::EffectWindow *w);
-    static void fillRegion(const QRegion &reg, const QColor &c);
 
     void setRoundness(int r);
-    void genMasks();
-    void genRect();
 
     void reconfigure(ReconfigureFlags flags) override;
 #if KWIN_EFFECT_API_VERSION > 231
@@ -55,10 +52,8 @@ protected Q_SLOTS:
 
 private:
     enum { TopLeft = 0, TopRight, BottomRight, BottomLeft, NTex };
-    KWin::GLTexture *m_tex[NTex];
-    KWin::GLTexture *m_rect[NTex];
-    int m_size, m_rSize, m_alpha;
-    QSize m_corner;
+    int m_size;
+    bool m_drawShadow;
     QRegion m_updateRegion;
     std::unique_ptr<KWin::GLShader> m_shader;
     QList<KWin::EffectWindow *> m_managed;

--- a/shapecorners.h
+++ b/shapecorners.h
@@ -53,13 +53,13 @@ protected Q_SLOTS:
 private:
     enum { TopLeft = 0, TopRight, BottomRight, BottomLeft, NTex };
     int m_size;
-    bool m_drawShadow;
+    QColor m_shadowColor;
     QList<KWin::EffectWindow *> m_managed;
 
     std::unique_ptr<KWin::GLShader> m_shader;
     int m_shader_cornerIndex = 0;
     int m_shader_windowActive = 0;
-    int m_shader_drawShadow = 0;
+    int m_shader_shadowColor = 0;
 };
 
 #endif //SHAPECORNERS_H

--- a/shapecorners_config.cpp
+++ b/shapecorners_config.cpp
@@ -38,12 +38,14 @@ public:
         : q(config)
         , roundness("roundness")
         , dsp("dsp")
+        , drawShadow("drawShadow")
         , defaultRoundness(5)
         , defaultShadows(false)
+        , defaultDrawShadow(true)
     {}
     ShapeCornersConfig *q;
-    QString roundness, dsp;
-    QVariant defaultRoundness, defaultShadows;
+    QString roundness, dsp, drawShadow;
+    QVariant defaultRoundness, defaultShadows, defaultDrawShadow;
     ConfigDialog *ui;
 };
 
@@ -69,6 +71,7 @@ ShapeCornersConfig::load()
     KConfigGroup conf = KSharedConfig::openConfig("shapecorners.conf")->group("General");
     d->ui->roundness->setValue(conf.readEntry(d->roundness, d->defaultRoundness).toInt());
     d->ui->dsp->setChecked(conf.readEntry(d->dsp, d->defaultShadows).toBool());
+    d->ui->drawShadow->setChecked(conf.readEntry(d->drawShadow, d->defaultDrawShadow).toBool());
     emit changed(false);
 }
 
@@ -79,6 +82,7 @@ ShapeCornersConfig::save()
     KConfigGroup conf = KSharedConfig::openConfig("shapecorners.conf")->group("General");
     conf.writeEntry(d->roundness, d->ui->roundness->value());
     conf.writeEntry(d->dsp, d->ui->dsp->isChecked());
+    conf.writeEntry(d->drawShadow, d->ui->drawShadow->isChecked());
     conf.sync();
     emit changed(false);
     OrgKdeKwinEffectsInterface interface(QStringLiteral("org.kde.KWin"),
@@ -93,6 +97,7 @@ ShapeCornersConfig::defaults()
     KCModule::defaults();
     d->ui->roundness->setValue(d->defaultRoundness.toInt());
     d->ui->dsp->setChecked(d->defaultShadows.toBool());
+    d->ui->drawShadow->setChecked(d->defaultDrawShadow.toBool());
     emit changed(true);
 }
 

--- a/shapecorners_config.cpp
+++ b/shapecorners_config.cpp
@@ -38,14 +38,14 @@ public:
         : q(config)
         , roundness("roundness")
         , dsp("dsp")
-        , drawShadow("drawShadow")
+        , shadowColor("shadowColor")
         , defaultRoundness(5)
         , defaultShadows(false)
-        , defaultDrawShadow(true)
+        , defaultShadowColor(QColor(Qt::black))
     {}
     ShapeCornersConfig *q;
-    QString roundness, dsp, drawShadow;
-    QVariant defaultRoundness, defaultShadows, defaultDrawShadow;
+    QString roundness, dsp, shadowColor;
+    QVariant defaultRoundness, defaultShadows, defaultShadowColor;
     ConfigDialog *ui;
 };
 
@@ -71,7 +71,10 @@ ShapeCornersConfig::load()
     KConfigGroup conf = KSharedConfig::openConfig("shapecorners.conf")->group("General");
     d->ui->roundness->setValue(conf.readEntry(d->roundness, d->defaultRoundness).toInt());
     d->ui->dsp->setChecked(conf.readEntry(d->dsp, d->defaultShadows).toBool());
-    d->ui->drawShadow->setChecked(conf.readEntry(d->drawShadow, d->defaultDrawShadow).toBool());
+    QColor shadowColor = conf.readEntry(d->shadowColor, d->defaultShadowColor).value<QColor>();
+    d->ui->drawShadowEnabled->setChecked(shadowColor.alpha() > 0);
+    shadowColor.setAlpha(255);
+    d->ui->shadowColor->setColor(shadowColor);
     emit changed(false);
 }
 
@@ -82,7 +85,9 @@ ShapeCornersConfig::save()
     KConfigGroup conf = KSharedConfig::openConfig("shapecorners.conf")->group("General");
     conf.writeEntry(d->roundness, d->ui->roundness->value());
     conf.writeEntry(d->dsp, d->ui->dsp->isChecked());
-    conf.writeEntry(d->drawShadow, d->ui->drawShadow->isChecked());
+    auto shadowColor = d->ui->shadowColor->color();
+    shadowColor.setAlpha(d->ui->drawShadowEnabled->isChecked()? 255: 0);
+    conf.writeEntry(d->shadowColor, shadowColor);
     conf.sync();
     emit changed(false);
     OrgKdeKwinEffectsInterface interface(QStringLiteral("org.kde.KWin"),
@@ -97,7 +102,8 @@ ShapeCornersConfig::defaults()
     KCModule::defaults();
     d->ui->roundness->setValue(d->defaultRoundness.toInt());
     d->ui->dsp->setChecked(d->defaultShadows.toBool());
-    d->ui->drawShadow->setChecked(d->defaultDrawShadow.toBool());
+    d->ui->shadowColor->setColor(d->defaultShadowColor.value<QColor>());
+    d->ui->drawShadowEnabled->setChecked(d->defaultShadowColor.value<QColor>().alpha() > 0);
     emit changed(true);
 }
 

--- a/shapecorners_config.ui
+++ b/shapecorners_config.ui
@@ -40,6 +40,13 @@
       </widget>
      </item>
      <item>
+      <widget class="QCheckBox" name="drawShadow">
+       <property name="text">
+        <string>Draw a fake shadow at corners</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="verticalSpacer">
        <property name="orientation">
         <enum>Qt::Vertical</enum>

--- a/shapecorners_config.ui
+++ b/shapecorners_config.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>300</height>
+    <height>191</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,6 +16,13 @@
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
     <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Roundness Radius</string>
+       </property>
+      </widget>
+     </item>
      <item>
       <widget class="QSlider" name="roundness">
        <property name="minimum">
@@ -40,11 +47,18 @@
       </widget>
      </item>
      <item>
-      <widget class="QCheckBox" name="drawShadow">
-       <property name="text">
-        <string>Draw a fake shadow at corners</string>
-       </property>
-      </widget>
+      <layout class="QGridLayout" name="gridLayout_2">
+       <item row="0" column="0">
+        <widget class="QCheckBox" name="drawShadowEnabled">
+         <property name="text">
+          <string>Draw Corner Shadows</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="KColorButton" name="shadowColor"/>
+       </item>
+      </layout>
      </item>
      <item>
       <spacer name="verticalSpacer">
@@ -63,6 +77,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>KColorButton</class>
+   <extends>QPushButton</extends>
+   <header>kcolorbutton.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
In this pull request, I am drawing **my own fake shadows at corners** because of issue #2.
I am drawing these shadows with the same shader that is responsible for rounding corners.

It took me a while to find the right gradient of shadow for active and inactive windows. I didn't know the right formula so I used try-and-error to find something acceptable.

Because I thought this approach might cause issues for some, I also added a checkbox to enable or disable it in the config window.