### PR TITLE
Optimize the effect and render once instead of 5 times

### DIFF
--- a/.github/workflows/glslangValidator.yml
+++ b/.github/workflows/glslangValidator.yml
@@ -1,0 +1,36 @@
+name: GLSL Validator
+
+on:
+  push:
+    branches: [ master, latest-shapecorners-code, kwin_5.23 ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  ubuntu2004:
+    # The CMake configure and build commands are platform agnostic and should work equally
+    # well on Windows or Mac.  You can convert this to a matrix build if you need
+    # cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v3
+
+    - name: Run  github-actions-tune
+      uses: abbbi/github-actions-tune@v1
+      
+    - name: Install Dependencies
+      uses: awalsh128/cache-apt-pkgs-action@staging
+      with:
+          packages: glslang-tools
+          version: 123.0
+          refresh: true
+
+    - name: Validate Shaders
+      run: glslangValidator shaders_110/shapecorners.frag shaders_140/shapecorners.frag

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ if (NOT EFFECTS_H OR NOT KWIN_GLUTILS OR NOT KWIN_EFFECTS OR NOT OPENGL)
     message(FATAL_ERROR "cant continue")
 endif (NOT EFFECTS_H OR NOT KWIN_GLUTILS OR NOT KWIN_EFFECTS OR NOT OPENGL)
 
-add_library(${SHAPECORNERS} MODULE shapecorners.cpp main.cpp dbus.h shapecorners.h)
+add_library(${SHAPECORNERS} MODULE shapecorners.cpp main.cpp dbus.h shapecorners.h ShaderManager.cpp ShaderManager.h ConfigModel.h ConfigModel.cpp)
 
 target_link_libraries(${SHAPECORNERS}
     PUBLIC
@@ -115,7 +115,7 @@ install(FILES shaders_110/shapecorners.frag DESTINATION ${DATAPATH}/kwin/shaders
 
 #config
 project(kwin4_shapecorners_config)
-set(kwin4_shapecorners_config_SOURCES shapecorners_config.cpp shapecorners_config.h)
+set(kwin4_shapecorners_config_SOURCES shapecorners_config.cpp shapecorners_config.h ConfigModel.cpp)
 ki18n_wrap_ui(kwin4_shapecorners_config_SOURCES shapecorners_config.ui)
 qt5_add_dbus_interface(kwin4_shapecorners_config_SOURCES org.kde.kwin.Effects.xml kwineffects_interface)
 add_library(kwin4_shapecorners_config MODULE ${kwin4_shapecorners_config_SOURCES})

--- a/ConfigModel.cpp
+++ b/ConfigModel.cpp
@@ -1,0 +1,42 @@
+//
+// Created by matin on 20/07/22.
+//
+
+#include <KConfigGroup>
+#include <KSharedConfig>
+#include "ConfigModel.h"
+
+const QString
+    key_size = "roundness",
+    key_dsp = "dsp",
+    key_shadowColor = "shadowColor",
+    key_outlineColor = "outlineColor",
+    key_outlineThickness = "outlineThickness";
+
+ConfigModel::ConfigModel():
+        m_size(10),
+        m_outlineThickness(1),
+        m_shadowColor(QColor(Qt::black)),
+        m_outlineColor(QColor(Qt::black)),
+        m_dsp(false)
+{
+}
+
+void ConfigModel::Load() {
+    KConfigGroup conf = KSharedConfig::openConfig("shapecorners.conf")->group("General");
+    m_size = conf.readEntry(key_size, m_size);
+    m_shadowColor = conf.readEntry(key_shadowColor, m_shadowColor);
+    m_outlineColor = conf.readEntry(key_outlineColor, m_outlineColor);
+    m_outlineThickness = conf.readEntry(key_outlineThickness, m_outlineThickness);
+    m_dsp = conf.readEntry(key_dsp, m_dsp);
+}
+
+void ConfigModel::Save() const {
+    KConfigGroup conf = KSharedConfig::openConfig("shapecorners.conf")->group("General");
+    conf.writeEntry(key_size, m_size);
+    conf.writeEntry(key_dsp, m_dsp);
+    conf.writeEntry(key_shadowColor, m_shadowColor);
+    conf.writeEntry(key_outlineColor, m_outlineColor);
+    conf.writeEntry(key_outlineThickness, m_outlineThickness);
+    conf.sync();
+}

--- a/ConfigModel.h
+++ b/ConfigModel.h
@@ -1,0 +1,23 @@
+//
+// Created by matin on 20/07/22.
+//
+
+#ifndef KWIN4_SHAPECORNERS_CONFIG_CONFIGMODEL_H
+#define KWIN4_SHAPECORNERS_CONFIG_CONFIGMODEL_H
+
+#include <QColor>
+
+class ConfigModel {
+public:
+    ConfigModel();
+    void Load();
+    void Save() const;
+
+    float  m_size,
+           m_outlineThickness;
+    QColor m_shadowColor,
+           m_outlineColor;
+    bool   m_dsp;
+};
+
+#endif //KWIN4_SHAPECORNERS_CONFIG_CONFIGMODEL_H

--- a/ShaderManager.cpp
+++ b/ShaderManager.cpp
@@ -1,0 +1,74 @@
+//
+// Created by matin on 20/07/22.
+//
+
+#include <kwinglplatform.h>
+#include <QFile>
+#include <QStandardPaths>
+#include <kwineffects.h>
+#include "ShaderManager.h"
+
+ShaderManager::ShaderManager():
+        m_manager(KWin::ShaderManager::instance())
+{
+    QString shadersDir(QStringLiteral("kwin/shaders/1.10/"));
+#ifdef KWIN_HAVE_OPENGLES
+    const qint64 coreVersionNumber = kVersionNumber(3, 0);
+#else
+    const qint64 version = KWin::kVersionNumber(1, 40);
+#endif
+    if (KWin::GLPlatform::instance()->glslVersion() >= version)
+        shadersDir = QStringLiteral("kwin/shaders/1.40/");
+
+    const QString fragmentshader = QStandardPaths::locate(QStandardPaths::GenericDataLocation, shadersDir + QStringLiteral("shapecorners.frag"));
+//    m_shader = KWin::ShaderManager::instance()->loadFragmentShader(KWin::ShaderManager::GenericShader, fragmentshader);
+    QFile file(fragmentshader);
+    if (file.open(QFile::ReadOnly))
+    {
+        QByteArray frag = file.readAll();
+        auto shader = m_manager->generateCustomShader(KWin::ShaderTrait::MapTexture, QByteArray(), frag);
+#if KWIN_EFFECT_API_VERSION >= 235
+        m_shader = std::move(shader);
+#else
+        m_shader.reset(shader);
+#endif
+        file.close();
+//        qDebug() << frag;
+//        qDebug() << "shader valid: " << m_shader->isValid();
+        if (m_shader->isValid())
+        {
+            m_shader_windowSize = m_shader->uniformLocation("windowSize");
+            m_shader_windowActive = m_shader->uniformLocation("windowActive");
+            m_shader_shadowColor = m_shader->uniformLocation("shadowColor");
+            m_shader_radius = m_shader->uniformLocation("radius");
+            m_shader_outlineColor = m_shader->uniformLocation("outlineColor");
+            m_shader_outlineThickness = m_shader->uniformLocation("outlineThickness");
+        }
+        else
+            qDebug() << "ShapeCorners: no valid shaders found! ShapeCorners will not work.";
+    }
+    else
+    {
+        qDebug() << "ShapeCorners: no shaders found! Exiting...";
+    }
+}
+
+bool ShaderManager::IsValid() const {
+    return m_shader && m_shader->isValid();
+}
+
+void ShaderManager::Bind(QMatrix4x4 mvp, const QRect& geo, bool windowActive, const ConfigModel& config) const {
+    m_manager->pushShader(m_shader.get());
+    mvp.translate((float)geo.x(), (float)geo.y());
+    m_shader->setUniform(KWin::GLShader::ModelViewProjectionMatrix, mvp);
+    m_shader->setUniform(m_shader_windowSize, QVector2D{(float)geo.width(), (float)geo.height()});
+    m_shader->setUniform(m_shader_windowActive, windowActive);
+    m_shader->setUniform(m_shader_shadowColor, config.m_shadowColor);
+    m_shader->setUniform(m_shader_radius, config.m_size);
+    m_shader->setUniform(m_shader_outlineColor, config.m_outlineColor);
+    m_shader->setUniform(m_shader_outlineThickness, config.m_outlineThickness);
+}
+
+void ShaderManager::Unbind() const {
+    m_manager->popShader();
+}

--- a/ShaderManager.h
+++ b/ShaderManager.h
@@ -1,0 +1,37 @@
+//
+// Created by matin on 20/07/22.
+//
+
+#ifndef KWIN4_SHAPECORNERS_CONFIG_SHADERMANAGER_H
+#define KWIN4_SHAPECORNERS_CONFIG_SHADERMANAGER_H
+
+#include <kwinglutils.h>
+#include <memory>
+#include "ConfigModel.h"
+
+namespace KWin {
+    class GLShader;
+    class ShaderManager;
+}
+
+class ShaderManager {
+public:
+    ShaderManager();
+
+    bool IsValid() const;
+    void Bind(QMatrix4x4 mvp, const QRect& geo, bool windowActive, const ConfigModel& config) const;
+    void Unbind() const;
+
+private:
+    std::unique_ptr<KWin::GLShader> m_shader;
+    KWin::ShaderManager* m_manager;
+    int m_shader_windowSize = 0;
+    int m_shader_windowActive = 0;
+    int m_shader_shadowColor = 0;
+    int m_shader_radius = 0;
+    int m_shader_outlineColor = 0;
+    int m_shader_outlineThickness = 0;
+};
+
+
+#endif //KWIN4_SHAPECORNERS_CONFIG_SHADERMANAGER_H

--- a/dbus.h
+++ b/dbus.h
@@ -3,7 +3,6 @@
 
 #include <QtDBus/QDBusAbstractAdaptor>
 #include "shapecorners.h"
-#include <KConfigGroup>
 
 namespace KWin
 {
@@ -21,12 +20,12 @@ public:
 public slots:
     Q_NOREPLY void setRoundness(int r)
     {
-        KConfigGroup conf = KSharedConfig::openConfig("shapecorners.conf")->group("General");
-        if (conf.readEntry("dsp", false))
-        {
-            conf.writeEntry("roundness", r);
-            conf.sync();
-            m_effect->setRoundness(r);
+        ConfigModel config;
+        config.Load();
+        if(config.m_dsp) {
+            config.m_size = r;
+            config.Save();
+            m_effect->setConfig(config);
         }
     }
     Q_NOREPLY void configure() { m_effect->reconfigure(KWin::Effect::ReconfigureAll); }

--- a/shaders_110/shapecorners.frag
+++ b/shaders_110/shapecorners.frag
@@ -1,8 +1,8 @@
 #version 110
 
 uniform sampler2D sampler;
-uniform int radius;
-uniform int cornerIndex;
+uniform float radius;
+uniform vec2 windowSize;
 uniform bool windowActive;
 uniform vec4 shadowColor;
 uniform vec4 outlineColor;
@@ -16,33 +16,34 @@ vec4 goTowards(vec4 fromColor, vec4 toColor, float percent) {
 }
 
 vec4 shadowCorner(float distance_from_center, vec4 backColor, bool isTopCorner) {
+    float r2 = radius * sqrt(2.0);
     if (windowActive) {
         if (isTopCorner) {
-            float percent = (distance_from_center + 0.15) / (sqrt(2.0)+0.2);
+            float percent = (distance_from_center + 0.15*radius) / (r2+0.2*radius);
             return goTowards(shadowColor, backColor, percent);
         }
         else {
-            float percent = (distance_from_center - 0.25) / (sqrt(2.0)+0.1);
+            float percent = (distance_from_center - 0.25*radius) / (r2+0.1*radius);
             return goTowards(shadowColor, backColor, percent);
         }
     }
     else {
         if (isTopCorner) {
-            float percent = (distance_from_center + 0.55) / (sqrt(2.0)+0.5);
+            float percent = (distance_from_center + 0.55*radius) / (r2+0.5*radius);
             return goTowards(shadowColor, backColor, percent);
         }
         else {
-            float percent = (distance_from_center) / (sqrt(2.0)+0.1);
+            float percent = (distance_from_center) / (r2+0.1*radius);
             return goTowards(shadowColor, backColor, percent);
         }
     }
 }
 
-vec4 shapeCorner(vec2 texcoord0, vec4 backColor, vec2 center, bool isTopCorner) {
-    float distance_from_center = distance(texcoord0, center);
-    if(distance_from_center < (1.0 - outlineThickness/float(radius)))
+vec4 shapeCorner(vec2 coord0, vec4 backColor, vec2 center, bool isTopCorner) {
+    float distance_from_center = distance(coord0, center);
+    if(distance_from_center < radius - outlineThickness)
         backColor.a = 0.0;
-    else if(distance_from_center < 1.0)
+    else if(distance_from_center < radius)
         backColor = outlineColor;
     else {
         if(shadowColor.a > 0.0)
@@ -53,16 +54,37 @@ vec4 shapeCorner(vec2 texcoord0, vec4 backColor, vec2 center, bool isTopCorner) 
     return backColor;
 }
 
-void main()
+void main(void)
 {
     vec4 tex = texture2D(sampler, texcoord0);
-    if(cornerIndex == 0)
-        tex = shapeCorner(texcoord0, tex, vec2(1, 0), true);
-    else if(cornerIndex == 1)
-        tex = shapeCorner(texcoord0, tex, vec2(0, 0), true);
-    else if(cornerIndex == 2)
-        tex = shapeCorner(texcoord0, tex, vec2(0, 1), false);
-    else if(cornerIndex == 3)
-        tex = shapeCorner(texcoord0, tex, vec2(1, 1), false);
+    vec2 coord0 = vec2(texcoord0.x*windowSize.x, texcoord0.y*windowSize.y);
+    if(coord0.x < radius) {
+        if(coord0.y < radius)
+            tex = shapeCorner(coord0, tex, vec2(radius, radius), false);
+        else if (coord0.y > windowSize.y - radius)
+            tex = shapeCorner(coord0, tex, vec2(radius, windowSize.y - radius), true);
+        else if (coord0.x < outlineThickness)
+            tex = outlineColor;
+        else
+            tex.a = 0.0;
+    }
+    else if(coord0.x > windowSize.x - radius) {
+        if(coord0.y < radius)
+            tex = shapeCorner(coord0, tex, vec2(windowSize.x - radius, radius), false);
+        else if (coord0.y > windowSize.y - radius)
+            tex = shapeCorner(coord0, tex, vec2(windowSize.x - radius, windowSize.y - radius), true);
+        else if (coord0.x > windowSize.x - outlineThickness)
+            tex = outlineColor;
+        else
+            tex.a = 0.0;
+    }
+    else {
+        if (coord0.y < outlineThickness)
+            tex = outlineColor;
+        else if (coord0.y > windowSize.y - outlineThickness)
+            tex = outlineColor;
+        else
+            tex.a = 0.0;
+    }
     gl_FragColor = tex;
 }

--- a/shaders_140/shapecorners.frag
+++ b/shaders_140/shapecorners.frag
@@ -1,8 +1,8 @@
 #version 140
 
 uniform sampler2D sampler;
-uniform int radius;
-uniform int cornerIndex;
+uniform float radius;
+uniform vec2 windowSize;
 uniform bool windowActive;
 uniform vec4 shadowColor;
 uniform vec4 outlineColor;
@@ -17,33 +17,34 @@ vec4 goTowards(vec4 fromColor, vec4 toColor, float percent) {
 }
 
 vec4 shadowCorner(float distance_from_center, vec4 backColor, bool isTopCorner) {
+    float r2 = radius * sqrt(2);
     if (windowActive) {
         if (isTopCorner) {
-            float percent = (distance_from_center + 0.15) / (sqrt(2)+0.2);
+            float percent = (distance_from_center + 0.15*radius) / (r2+0.2*radius);
             return goTowards(shadowColor, backColor, percent);
         }
         else {
-            float percent = (distance_from_center - 0.25) / (sqrt(2)+0.1);
+            float percent = (distance_from_center - 0.25*radius) / (r2+0.1*radius);
             return goTowards(shadowColor, backColor, percent);
         }
     }
     else {
         if (isTopCorner) {
-            float percent = (distance_from_center + 0.55) / (sqrt(2)+0.5);
+            float percent = (distance_from_center + 0.55*radius) / (r2+0.5*radius);
             return goTowards(shadowColor, backColor, percent);
         }
         else {
-            float percent = (distance_from_center) / (sqrt(2)+0.1);
+            float percent = (distance_from_center) / (r2+0.1*radius);
             return goTowards(shadowColor, backColor, percent);
         }
     }
 }
 
-vec4 shapeCorner(vec2 texcoord0, vec4 backColor, vec2 center, bool isTopCorner) {
-    float distance_from_center = distance(texcoord0, center);
-    if(distance_from_center < 1 - outlineThickness/radius)
+vec4 shapeCorner(vec2 coord0, vec4 backColor, vec2 center, bool isTopCorner) {
+    float distance_from_center = distance(coord0, center);
+    if(distance_from_center < radius - outlineThickness)
         backColor.a = 0;
-    else if(distance_from_center < 1)
+    else if(distance_from_center < radius)
         backColor = outlineColor;
     else {
         if(shadowColor.a > 0)
@@ -57,13 +58,34 @@ vec4 shapeCorner(vec2 texcoord0, vec4 backColor, vec2 center, bool isTopCorner) 
 void main(void)
 {
     vec4 tex = texture(sampler, texcoord0);
-    if(cornerIndex == 0)
-        tex = shapeCorner(texcoord0, tex, vec2(1, 0), true);
-    else if(cornerIndex == 1)
-        tex = shapeCorner(texcoord0, tex, vec2(0, 0), true);
-    else if(cornerIndex == 2)
-        tex = shapeCorner(texcoord0, tex, vec2(0, 1), false);
-    else if(cornerIndex == 3)
-        tex = shapeCorner(texcoord0, tex, vec2(1, 1), false);
+    vec2 coord0 = vec2(texcoord0.x*windowSize.x, texcoord0.y*windowSize.y);
+    if(coord0.x < radius) {
+        if(coord0.y < radius)
+            tex = shapeCorner(coord0, tex, vec2(radius, radius), false);
+        else if (coord0.y > windowSize.y - radius)
+            tex = shapeCorner(coord0, tex, vec2(radius, windowSize.y - radius), true);
+        else if (coord0.x < outlineThickness)
+            tex = outlineColor;
+        else
+            tex.a = 0;
+    }
+    else if(coord0.x > windowSize.x - radius) {
+        if(coord0.y < radius)
+            tex = shapeCorner(coord0, tex, vec2(windowSize.x - radius, radius), false);
+        else if (coord0.y > windowSize.y - radius)
+            tex = shapeCorner(coord0, tex, vec2(windowSize.x - radius, windowSize.y - radius), true);
+        else if (coord0.x > windowSize.x - outlineThickness)
+            tex = outlineColor;
+        else
+            tex.a = 0;
+    }
+    else {
+        if (coord0.y < outlineThickness)
+            tex = outlineColor;
+        else if (coord0.y > windowSize.y - outlineThickness)
+            tex = outlineColor;
+        else
+            tex.a = 0;
+    }
     fragColor = tex;
 }

--- a/shapecorners.cpp
+++ b/shapecorners.cpp
@@ -96,7 +96,7 @@ ShapeCornersEffect::prePaintWindow(KWin::EffectWindow *w, KWin::WindowPrePaintDa
         return;
     }
 
-#if KWIN_EFFECT_API_VERSION <= 235
+#if KWIN_EFFECT_API_VERSION < 235
     const QRect& geo = w->frameGeometry();
 #else
     const QRectF& geoF = w->frameGeometry();
@@ -153,7 +153,7 @@ ShapeCornersEffect::paintWindow(KWin::EffectWindow *w, int mask, QRegion region,
 #endif
 
     //copy the background
-#if KWIN_EFFECT_API_VERSION <= 235
+#if KWIN_EFFECT_API_VERSION < 235
     const QRect& geo = w->frameGeometry();
 #else
     const QRectF& geoF = w->frameGeometry();

--- a/shapecorners.cpp
+++ b/shapecorners.cpp
@@ -21,7 +21,6 @@
 #include "shapecorners.h"
 #include <QPainter>
 #include <QImage>
-#include <QMatrix4x4>
 #include <QDBusConnection>
 #include <kwindowsystem.h>
 #include <kwingltexture.h>
@@ -97,7 +96,12 @@ ShapeCornersEffect::prePaintWindow(KWin::EffectWindow *w, KWin::WindowPrePaintDa
         return;
     }
 
-    const auto& geo = w->frameGeometry();
+#if KWIN_EFFECT_API_VERSION <= 235
+    const QRect& geo = w->frameGeometry();
+#else
+    const QRectF& geoF = w->frameGeometry();
+    const QRect geo ((int)geo.left(), (int)geo.top(), (int)geo.width(), (int)geo.height());
+#endif
     data.paint += geo;
 #if KWIN_EFFECT_API_VERSION < 234
     data.clip -= geo;
@@ -149,7 +153,12 @@ ShapeCornersEffect::paintWindow(KWin::EffectWindow *w, int mask, QRegion region,
 #endif
 
     //copy the background
-    const auto& geo = w->frameGeometry();
+#if KWIN_EFFECT_API_VERSION <= 235
+    const QRect& geo = w->frameGeometry();
+#else
+    const QRectF& geoF = w->frameGeometry();
+    const QRect geo ((int)geo.left(), (int)geo.top(), (int)geo.width(), (int)geo.height());
+#endif
     const auto& s = KWin::effects->virtualScreenGeometry();
     KWin::GLTexture back (GL_RGBA8, geo.size());
     back.bind();

--- a/shapecorners.h
+++ b/shapecorners.h
@@ -21,9 +21,7 @@
 #define SHAPECORNERS_H
 
 #include <kwineffects.h>
-#include <memory>
-
-namespace KWin { class GLTexture; }
+#include "ShaderManager.h"
 
 class Q_DECL_EXPORT ShapeCornersEffect : public KWin::Effect
 {
@@ -36,7 +34,7 @@ public:
     static bool enabledByDefault() { return supported(); }
     static bool isMaximized(KWin::EffectWindow *w);
 
-    void setRoundness(int r);
+    void setConfig(const ConfigModel& config) { m_config = config; }
 
     void reconfigure(ReconfigureFlags flags) override;
 #if KWIN_EFFECT_API_VERSION > 231
@@ -51,19 +49,9 @@ protected Q_SLOTS:
     void windowAdded(KWin::EffectWindow *window);
 
 private:
-    enum { TopLeft = 0, TopRight, BottomRight, BottomLeft, NTex };
-    int m_size;
-    float m_outlineThickness;
-    QColor m_shadowColor, m_outlineColor;
     QList<KWin::EffectWindow *> m_managed;
-
-    std::unique_ptr<KWin::GLShader> m_shader;
-    int m_shader_cornerIndex = 0;
-    int m_shader_windowActive = 0;
-    int m_shader_shadowColor = 0;
-    int m_shader_radius = 0;
-    int m_shader_outlineColor = 0;
-    int m_shader_outlineThickness = 0;
+    ShaderManager m_shaderManager;
+    ConfigModel m_config;
 };
 
 #endif //SHAPECORNERS_H

--- a/shapecorners_config.cpp
+++ b/shapecorners_config.cpp
@@ -36,22 +36,8 @@ class ShapeCornersConfig::Private
 public:
     Private(ShapeCornersConfig *config)
         : q(config)
-        , roundness("roundness")
-        , dsp("dsp")
-        , shadowColor("shadowColor")
-        , outlineColor("outlineColor")
-        , outlineThickness("outlineThickness")
-        , defaultRoundness(5)
-        , defaultShadows(false)
-        , defaultShadowColor(QColor(Qt::black))
-        , defaultOutlineColor(QColor(Qt::black))
-        , defaultOutlineThickness(1.0f)
     {}
     ShapeCornersConfig *q;
-    QString roundness, dsp, shadowColor,
-            outlineColor, outlineThickness;
-    QVariant defaultRoundness, defaultShadows, defaultShadowColor,
-            defaultOutlineColor, defaultOutlineThickness;
     ConfigDialog *ui;
 };
 
@@ -74,17 +60,17 @@ void
 ShapeCornersConfig::load()
 {
     KCModule::load();
-    KConfigGroup conf = KSharedConfig::openConfig("shapecorners.conf")->group("General");
-    d->ui->roundness->setValue(conf.readEntry(d->roundness, d->defaultRoundness).toInt());
-    d->ui->dsp->setChecked(conf.readEntry(d->dsp, d->defaultShadows).toBool());
-    QColor shadowColor = conf.readEntry(d->shadowColor, d->defaultShadowColor).value<QColor>();
+    m_config.Load();
+    d->ui->roundness->setValue(m_config.m_size);
+    d->ui->dsp->setChecked(m_config.m_dsp);
+    QColor shadowColor = m_config.m_shadowColor;
     d->ui->drawShadowEnabled->setChecked(shadowColor.alpha() > 0);
     shadowColor.setAlpha(255);
     d->ui->shadowColor->setColor(shadowColor);
-    QColor outlineColor = conf.readEntry(d->outlineColor, d->defaultOutlineColor).value<QColor>();
+    QColor outlineColor = m_config.m_outlineColor;
     d->ui->drawOutlineEnabled->setChecked(outlineColor.alpha() > 0);
     d->ui->outlineColor->setColor(outlineColor);
-    d->ui->outlineThickness->setValue(conf.readEntry(d->outlineThickness, d->defaultOutlineThickness).toFloat());
+    d->ui->outlineThickness->setValue(m_config.m_outlineThickness);
     emit changed(false);
 }
 
@@ -92,18 +78,16 @@ void
 ShapeCornersConfig::save()
 {
     KCModule::save();
-    KConfigGroup conf = KSharedConfig::openConfig("shapecorners.conf")->group("General");
-    conf.writeEntry(d->roundness, d->ui->roundness->value());
-    conf.writeEntry(d->dsp, d->ui->dsp->isChecked());
-    auto shadowColor = d->ui->shadowColor->color();
-    shadowColor.setAlpha(d->ui->drawShadowEnabled->isChecked()? 255: 0);
-    conf.writeEntry(d->shadowColor, shadowColor);
-    auto outlineColor = d->ui->outlineColor->color();
+    m_config.m_size = d->ui->roundness->value();
+    m_config.m_dsp = d->ui->dsp->isChecked();
+    m_config.m_shadowColor = d->ui->shadowColor->color();
+    m_config.m_shadowColor.setAlpha(d->ui->drawShadowEnabled->isChecked()? 255: 0);
+    m_config.m_outlineColor = d->ui->outlineColor->color();
     if(!d->ui->drawOutlineEnabled->isChecked())
-        outlineColor.setAlpha(0);
-    conf.writeEntry(d->outlineColor, outlineColor);
-    conf.writeEntry(d->outlineThickness, d->ui->outlineThickness->value());
-    conf.sync();
+        m_config.m_outlineColor.setAlpha(0);
+    m_config.m_outlineThickness = d->ui->outlineThickness->value();
+    m_config.Save();
+
     emit changed(false);
     OrgKdeKwinEffectsInterface interface(QStringLiteral("org.kde.KWin"),
                                          QStringLiteral("/Effects"),
@@ -115,13 +99,17 @@ void
 ShapeCornersConfig::defaults()
 {
     KCModule::defaults();
-    d->ui->roundness->setValue(d->defaultRoundness.toInt());
-    d->ui->dsp->setChecked(d->defaultShadows.toBool());
-    d->ui->shadowColor->setColor(d->defaultShadowColor.value<QColor>());
-    d->ui->drawShadowEnabled->setChecked(d->defaultShadowColor.value<QColor>().alpha() > 0);
-    d->ui->outlineColor->setColor(d->defaultOutlineColor.value<QColor>());
-    d->ui->drawOutlineEnabled->setChecked(d->defaultOutlineColor.value<QColor>().alpha() > 0);
-    d->ui->outlineThickness->setValue(d->defaultOutlineThickness.toFloat());
+    ConfigModel defaultConfig;
+    d->ui->roundness->setValue(m_config.m_size);
+    d->ui->dsp->setChecked(m_config.m_dsp);
+    QColor shadowColor = m_config.m_shadowColor;
+    d->ui->drawShadowEnabled->setChecked(shadowColor.alpha() > 0);
+    shadowColor.setAlpha(255);
+    d->ui->shadowColor->setColor(shadowColor);
+    QColor outlineColor = m_config.m_outlineColor;
+    d->ui->drawOutlineEnabled->setChecked(outlineColor.alpha() > 0);
+    d->ui->outlineColor->setColor(outlineColor);
+    d->ui->outlineThickness->setValue(m_config.m_outlineThickness);
     emit changed(true);
 }
 

--- a/shapecorners_config.h
+++ b/shapecorners_config.h
@@ -1,5 +1,6 @@
  
 #include <kcmodule.h>
+#include <ConfigModel.h>
 
 class ShapeCornersConfig : public KCModule
 {
@@ -13,6 +14,7 @@ public slots:
     void defaults() override;
 
 private:
+    ConfigModel m_config;
     class Private;
     Private * const d;
     friend class Private;


### PR DESCRIPTION
To address issue #50, this pull request combines all OpenGL render requests into only one. Therefore, it improves the performance of the effect. The screenshot below shows that the FPS only drops to 25 which is better than 15.
![Optimized](https://user-images.githubusercontent.com/7337168/180565906-3b53f6d8-00e2-473a-95a4-e19ba22d0176.png)