### PR TITLE
Add separate outline color for inactive windows

### DIFF
--- a/ConfigModel.cpp
+++ b/ConfigModel.cpp
@@ -11,6 +11,7 @@ const QString
     key_dsp = "dsp",
     key_shadowColor = "shadowColor",
     key_outlineColor = "outlineColor",
+    key_inactiveOutlineColor = "inactiveOutlineColor",
     key_outlineThickness = "outlineThickness";
 
 ConfigModel::ConfigModel():
@@ -18,6 +19,7 @@ ConfigModel::ConfigModel():
         m_outlineThickness(1),
         m_shadowColor(QColor(Qt::black)),
         m_outlineColor(QColor(Qt::black)),
+        m_inactiveOutlineColor(QColor(Qt::black)),
         m_dsp(false)
 {
 }
@@ -27,6 +29,7 @@ void ConfigModel::Load() {
     m_size = conf.readEntry(key_size, m_size);
     m_shadowColor = conf.readEntry(key_shadowColor, m_shadowColor);
     m_outlineColor = conf.readEntry(key_outlineColor, m_outlineColor);
+    m_inactiveOutlineColor = conf.readEntry(key_inactiveOutlineColor,m_inactiveOutlineColor);
     m_outlineThickness = conf.readEntry(key_outlineThickness, m_outlineThickness);
     m_dsp = conf.readEntry(key_dsp, m_dsp);
 }
@@ -37,6 +40,7 @@ void ConfigModel::Save() const {
     conf.writeEntry(key_dsp, m_dsp);
     conf.writeEntry(key_shadowColor, m_shadowColor);
     conf.writeEntry(key_outlineColor, m_outlineColor);
+    conf.writeEntry(key_inactiveOutlineColor,m_inactiveOutlineColor);
     conf.writeEntry(key_outlineThickness, m_outlineThickness);
     conf.sync();
 }

--- a/ConfigModel.h
+++ b/ConfigModel.h
@@ -16,7 +16,8 @@ public:
     float  m_size,
            m_outlineThickness;
     QColor m_shadowColor,
-           m_outlineColor;
+           m_outlineColor,
+	   m_inactiveOutlineColor;
     bool   m_dsp;
 };
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This effect started as a fork of [shapecorners](https://sourceforge.net/projects
 - Compatiblity with KWin from versions 5.23 to 5.26 - by [matinlotfali](https://github.com/matinlotfali)
 - Disable effect when window gets maximized - by [matinlotfali](https://github.com/matinlotfali)
 - Cleanups for the plugin logic, remove unneeded dependencies from CMakeLists.txt file - by [alex1701c](https://github.com/alex1701c)
+- Separate outline color for active and inactive windows - by [OrkenWhite](https://github.com/OrkenWhite)
 
 # How to build from source code:
 

--- a/ShaderManager.cpp
+++ b/ShaderManager.cpp
@@ -65,7 +65,7 @@ void ShaderManager::Bind(QMatrix4x4 mvp, const QRect& geo, bool windowActive, co
     m_shader->setUniform(m_shader_windowActive, windowActive);
     m_shader->setUniform(m_shader_shadowColor, config.m_shadowColor);
     m_shader->setUniform(m_shader_radius, config.m_size);
-    m_shader->setUniform(m_shader_outlineColor, config.m_outlineColor);
+    m_shader->setUniform(m_shader_outlineColor, windowActive ? config.m_outlineColor : config.m_inactiveOutlineColor);
     m_shader->setUniform(m_shader_outlineThickness, config.m_outlineThickness);
 }
 

--- a/shapecorners_config.cpp
+++ b/shapecorners_config.cpp
@@ -68,8 +68,10 @@ ShapeCornersConfig::load()
     shadowColor.setAlpha(255);
     d->ui->shadowColor->setColor(shadowColor);
     QColor outlineColor = m_config.m_outlineColor;
+    QColor inactiveOutlineColor = m_config.m_inactiveOutlineColor;
     d->ui->drawOutlineEnabled->setChecked(outlineColor.alpha() > 0);
     d->ui->outlineColor->setColor(outlineColor);
+    d->ui->inactiveOutlineColor->setColor(inactiveOutlineColor);
     d->ui->outlineThickness->setValue(m_config.m_outlineThickness);
     emit changed(false);
 }
@@ -83,8 +85,11 @@ ShapeCornersConfig::save()
     m_config.m_shadowColor = d->ui->shadowColor->color();
     m_config.m_shadowColor.setAlpha(d->ui->drawShadowEnabled->isChecked()? 255: 0);
     m_config.m_outlineColor = d->ui->outlineColor->color();
-    if(!d->ui->drawOutlineEnabled->isChecked())
+    m_config.m_inactiveOutlineColor = d->ui->inactiveOutlineColor->color();
+    if(!d->ui->drawOutlineEnabled->isChecked()){
         m_config.m_outlineColor.setAlpha(0);
+        m_config.m_inactiveOutlineColor.setAlpha(0);
+    }
     m_config.m_outlineThickness = d->ui->outlineThickness->value();
     m_config.Save();
 
@@ -107,8 +112,10 @@ ShapeCornersConfig::defaults()
     shadowColor.setAlpha(255);
     d->ui->shadowColor->setColor(shadowColor);
     QColor outlineColor = m_config.m_outlineColor;
+    QColor inactiveOutlineColor = m_config.m_inactiveOutlineColor;
     d->ui->drawOutlineEnabled->setChecked(outlineColor.alpha() > 0);
     d->ui->outlineColor->setColor(outlineColor);
+    d->ui->inactiveOutlineColor->setColor(inactiveOutlineColor);
     d->ui->outlineThickness->setValue(m_config.m_outlineThickness);
     emit changed(true);
 }

--- a/shapecorners_config.ui
+++ b/shapecorners_config.ui
@@ -66,7 +66,7 @@
           <item row="0" column="0">
            <widget class="QLabel" name="outlineColorLabel">
             <property name="text">
-             <string>Outline Color</string>
+             <string>Active Window Outline Color</string>
             </property>
            </widget>
           </item>
@@ -106,7 +106,7 @@
           <item row="1" column="0">
            <widget class="QLabel" name="inactiveOutlineColorLabel">
             <property name="text">
-             <string>Inactive Outline Color</string>
+             <string>Inactive Window Outline Color</string>
             </property>
            </widget>
           </item>

--- a/shapecorners_config.ui
+++ b/shapecorners_config.ui
@@ -70,14 +70,21 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
+          <item row="0" column="1">
+           <widget class="KColorButton" name="outlineColor">
+            <property name="alphaChannelEnabled">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
            <widget class="QLabel" name="thicknessLabel">
             <property name="text">
              <string>Thickness</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
+          <item row="2" column="1">
            <widget class="QDoubleSpinBox" name="outlineThickness">
             <property name="decimals">
              <number>1</number>
@@ -96,12 +103,15 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="1">
-           <widget class="KColorButton" name="outlineColor">
-            <property name="alphaChannelEnabled">
-             <bool>true</bool>
+          <item row="1" column="0">
+           <widget class="QLabel" name="inactiveOutlineColorLabel">
+            <property name="text">
+             <string>Inactive Outline Color</string>
             </property>
            </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="KColorButton" name="inactiveOutlineColor"/>
           </item>
          </layout>
         </item>
@@ -159,6 +169,11 @@
    <class>KColorButton</class>
    <extends>QPushButton</extends>
    <header>kcolorbutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>KColorCombo</class>
+   <extends>QComboBox</extends>
+   <header>kcolorcombo.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/shapecorners_config.ui
+++ b/shapecorners_config.ui
@@ -111,7 +111,11 @@
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="KColorButton" name="inactiveOutlineColor"/>
+           <widget class="KColorButton" name="inactiveOutlineColor">
+            <property name="alphaChannelEnabled">
+	     <bool>true</bool>
+	    </property>
+	   </widget>
           </item>
          </layout>
         </item>
@@ -169,11 +173,6 @@
    <class>KColorButton</class>
    <extends>QPushButton</extends>
    <header>kcolorbutton.h</header>
-  </customwidget>
-  <customwidget>
-   <class>KColorCombo</class>
-   <extends>QComboBox</extends>
-   <header>kcolorcombo.h</header>
   </customwidget>
  </customwidgets>
  <resources/>


### PR DESCRIPTION
This adds the ability to set a separate color for inactive windows, like in some tiling window managers.
![image](https://user-images.githubusercontent.com/73890378/180657399-9e90ef50-cf92-4a6f-8b1b-08b836aefc8c.png)
