### PR TITLE
Switch to C++ 20 to support the latest KWinEffect

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ project(${SHAPECORNERS})
 
 set(QT_MIN_VERSION "5.4.0")
 set(KF5_MIN_VERSION "5.68.0")
+set(CMAKE_CXX_STANDARD 20)
 
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose Release or Debug" FORCE)


### PR DESCRIPTION
I noticed that in the most recent update of **KDE Neon Unstable**, the `kwineffect.h` is using `std::span` which was introduced in C++ 20. 

So in this pull request, I try to compile and test compilations in different distributions with C++ 20