### PR TITLE
Fix the issue when the window changes the decoration status and is left without a round corner

### DIFF
--- a/src/ShapeCornersEffect.h
+++ b/src/ShapeCornersEffect.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <kwineffects.h>
+#include <set>
 #include "ShapeCornersShader.h"
 
 #if KWIN_EFFECT_API_VERSION >= 236
@@ -50,7 +51,10 @@ protected Q_SLOTS:
     void windowRemoved(KWin::EffectWindow *window);
 
 private:
-    QSet<KWin::EffectWindow*> m_managed;
+    std::set<const KWin::EffectWindow*> m_managed;
     ShapeCornersShader m_shaderManager;
+
+    bool hasEffect(const KWin::EffectWindow *w) const;
+    static bool isMaximized(const KWin::EffectWindow *w);
 };
 


### PR DESCRIPTION
This pull request fixes the issue when the window changes the decoration status and is left without a round corner. This was due to the assumption that windows don't change their decoration status.

To fix this, the decoration status needs to be repeatedly checked.