### PR TITLE
Add the ability to choose from KDE Plasma's decoration colour (including the accent colour)

### DIFF
--- a/src/ShapeCornersShader.cpp
+++ b/src/ShapeCornersShader.cpp
@@ -6,10 +6,12 @@
 #include <QFile>
 #include <QStandardPaths>
 #include <kwineffects.h>
+#include <QWidget>
 #include "ShapeCornersShader.h"
 
 ShapeCornersShader::ShapeCornersShader():
-        m_manager(KWin::ShaderManager::instance())
+        m_manager(KWin::ShaderManager::instance()),
+        m_palette(QWidget().palette())
 {
     const QString shadersDir = IsLegacy()? "kwin/shaders/1.10/": "kwin/shaders/1.40/";
     const QString fragmentshader = QStandardPaths::locate(QStandardPaths::GenericDataLocation, shadersDir + QStringLiteral("shapecorners.frag"));
@@ -59,6 +61,7 @@ bool isWindowActive(KWin::EffectWindow *w) {
 
 const std::unique_ptr<KWin::GLShader>&
 ShapeCornersShader::Bind(KWin::EffectWindow *w) const {
+    QColor outlineColor, shadowColor;
     auto xy = QVector2D((w->frameGeometry().left() - w->expandedGeometry().left()),
                         (w->frameGeometry().top() - w->expandedGeometry().top()));
     m_manager->pushShader(m_shader.get());
@@ -66,12 +69,36 @@ ShapeCornersShader::Bind(KWin::EffectWindow *w) const {
     m_shader->setUniform(m_shader_windowExpandedSize, QVector2D(w->expandedGeometry().width(), w->expandedGeometry().height()));
     m_shader->setUniform(m_shader_windowTopLeft, xy);
     m_shader->setUniform(m_shader_windowHasDecoration, w->hasDecoration());
-    m_shader->setUniform(m_shader_shadowColor, isWindowActive(w) ? ShapeCornersConfig::shadowColor(): ShapeCornersConfig::inactiveShadowColor());
-    m_shader->setUniform(m_shader_shadowSize, isWindowActive(w) ? (float)ShapeCornersConfig::shadowSize(): (float)ShapeCornersConfig::inactiveShadowSize());
-    m_shader->setUniform(m_shader_radius, (float)ShapeCornersConfig::size());
-    m_shader->setUniform(m_shader_outlineColor, isWindowActive(w) ? ShapeCornersConfig::outlineColor() : ShapeCornersConfig::inactiveOutlineColor());
-    m_shader->setUniform(m_shader_outlineThickness, (float)ShapeCornersConfig::outlineThickness());
     m_shader->setUniform(m_shader_front, 0);
+    if (isWindowActive(w)) {
+        m_shader->setUniform(m_shader_shadowSize, (float)ShapeCornersConfig::shadowSize());
+        m_shader->setUniform(m_shader_radius, (float)ShapeCornersConfig::size());
+        m_shader->setUniform(m_shader_outlineThickness, (float)ShapeCornersConfig::outlineThickness());
+
+        outlineColor = ShapeCornersConfig::activeOutlineUsePalette() ?
+            m_palette.color(QPalette::Active, static_cast<QPalette::ColorRole>(ShapeCornersConfig::activeOutlinePalette())):
+            ShapeCornersConfig::outlineColor();
+        shadowColor = ShapeCornersConfig::activeShadowUsePalette() ?
+            m_palette.color(QPalette::Active, static_cast<QPalette::ColorRole>(ShapeCornersConfig::activeShadowPalette())):
+            ShapeCornersConfig::shadowColor();
+        outlineColor.setAlpha(ShapeCornersConfig::activeOutlineAlpha());
+        shadowColor.setAlpha(ShapeCornersConfig::activeShadowAlpha());
+    } else {
+        m_shader->setUniform(m_shader_shadowSize, (float)ShapeCornersConfig::inactiveShadowSize());
+        m_shader->setUniform(m_shader_radius, (float)ShapeCornersConfig::inactiveCornerRadius());
+        m_shader->setUniform(m_shader_outlineThickness, (float)ShapeCornersConfig::inactiveOutlineThickness());
+
+        outlineColor = ShapeCornersConfig::inactiveOutlineUsePalette() ?
+                       m_palette.color(QPalette::Active, static_cast<QPalette::ColorRole>(ShapeCornersConfig::inactiveOutlinePalette())):
+                       ShapeCornersConfig::inactiveOutlineColor();
+        shadowColor = ShapeCornersConfig::inactiveShadowUsePalette() ?
+                      m_palette.color(QPalette::Active, static_cast<QPalette::ColorRole>(ShapeCornersConfig::inactiveShadowPalette())):
+                      ShapeCornersConfig::inactiveShadowColor();
+        outlineColor.setAlpha(ShapeCornersConfig::inactiveOutlineAlpha());
+        shadowColor.setAlpha(ShapeCornersConfig::inactiveShadowAlpha());
+    }
+    m_shader->setUniform(m_shader_outlineColor, outlineColor);
+    m_shader->setUniform(m_shader_shadowColor, shadowColor);
     return m_shader;
 }
 

--- a/src/ShapeCornersShader.h
+++ b/src/ShapeCornersShader.h
@@ -7,6 +7,7 @@
 
 #include <kwinglutils.h>
 #include <memory>
+#include <QPalette>
 #include "ShapeCornersConfig.h"
 
 namespace KWin {
@@ -28,6 +29,7 @@ public:
 private:
     std::unique_ptr<KWin::GLShader> m_shader;
     KWin::ShaderManager* m_manager;
+    QPalette m_palette;
     int m_shader_windowSize = 0;
     int m_shader_windowExpandedSize = 0;
     int m_shader_windowTopLeft = 0;

--- a/src/kcm/ShapeCornersKCM.cpp
+++ b/src/kcm/ShapeCornersKCM.cpp
@@ -13,6 +13,36 @@ ShapeCornersKCM::ShapeCornersKCM(QWidget* parent, const QVariantList& args)
 {
     ui->setupUi(this);
     addConfig(ShapeCornersConfig::self(), this);
+    update_colors();
+
+    QPixmap pix (16, 16);
+    for (int index = 0; index < ui->kcfg_ActiveOutlinePalette->count(); ++index) {
+        auto c = palette().color(QPalette::Active, static_cast<QPalette::ColorRole>(index));
+        pix.fill(c);
+        QIcon icon (pix);
+        ui->kcfg_ActiveOutlinePalette->setItemIcon(index, icon);
+        ui->kcfg_ActiveShadowPalette->setItemIcon(index, icon);
+
+        c = palette().color(QPalette::Inactive, static_cast<QPalette::ColorRole>(index));
+        pix.fill(c);
+        QIcon icon2 (pix);
+        ui->kcfg_InactiveOutlinePalette->setItemIcon(index, icon2);
+        ui->kcfg_InactiveShadowPalette->setItemIcon(index, icon2);
+    }
+
+    connect(ui->kcfg_ActiveOutlinePalette, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &ShapeCornersKCM::update_colors);
+    connect(ui->kcfg_InactiveOutlinePalette, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &ShapeCornersKCM::update_colors);
+    connect(ui->kcfg_OutlineColor, &KColorButton::changed, this, &ShapeCornersKCM::update_colors);
+    connect(ui->kcfg_InactiveOutlineColor, &KColorButton::changed, this, &ShapeCornersKCM::update_colors);
+    connect(ui->kcfg_ActiveOutlineUsePalette, &QRadioButton::toggled, this, &ShapeCornersKCM::update_colors);
+    connect(ui->kcfg_InactiveOutlineUsePalette, &QRadioButton::toggled, this, &ShapeCornersKCM::update_colors);
+
+    connect(ui->kcfg_ActiveShadowPalette, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &ShapeCornersKCM::update_colors);
+    connect(ui->kcfg_ActiveShadowPalette, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &ShapeCornersKCM::update_colors);
+    connect(ui->kcfg_ShadowColor, &KColorButton::changed, this, &ShapeCornersKCM::update_colors);
+    connect(ui->kcfg_InactiveShadowColor, &KColorButton::changed, this, &ShapeCornersKCM::update_colors);
+    connect(ui->kcfg_ActiveShadowUsePalette, &QRadioButton::toggled, this, &ShapeCornersKCM::update_colors);
+    connect(ui->kcfg_InactiveShadowUsePalette, &QRadioButton::toggled, this, &ShapeCornersKCM::update_colors);
 }
 
 void
@@ -28,4 +58,30 @@ ShapeCornersKCM::save()
 
 ShapeCornersKCM::~ShapeCornersKCM() {
     delete ui;
+}
+
+void ShapeCornersKCM::update_colors() {
+    QColor color;
+    bool checked;
+    int index;
+
+    checked = ui->kcfg_ActiveOutlineUsePalette->isChecked();
+    index = ui->kcfg_ActiveOutlinePalette->currentIndex();
+    color = checked ? palette().color(QPalette::Active, static_cast<QPalette::ColorRole>(index)): ui->kcfg_OutlineColor->color();
+    ui->kcfg_ActiveOutlineAlpha->setSecondColor(color);
+
+    checked = ui->kcfg_InactiveOutlineUsePalette->isChecked();
+    index = ui->kcfg_InactiveOutlinePalette->currentIndex();
+    color = checked ? palette().color(QPalette::Inactive, static_cast<QPalette::ColorRole>(index)): ui->kcfg_InactiveOutlineColor->color();
+    ui->kcfg_InactiveOutlineAlpha->setSecondColor(color);
+
+    checked = ui->kcfg_ActiveShadowUsePalette->isChecked();
+    index = ui->kcfg_ActiveShadowPalette->currentIndex();
+    color = checked ? palette().color(QPalette::Active, static_cast<QPalette::ColorRole>(index)): ui->kcfg_ShadowColor->color();
+    ui->kcfg_ActiveShadowAlpha->setSecondColor(color);
+
+    checked = ui->kcfg_InactiveShadowUsePalette->isChecked();
+    index = ui->kcfg_InactiveShadowPalette->currentIndex();
+    color = checked ? palette().color(QPalette::Inactive, static_cast<QPalette::ColorRole>(index)): ui->kcfg_InactiveShadowColor->color();
+    ui->kcfg_InactiveShadowAlpha->setSecondColor(color);
 }

--- a/src/kcm/ShapeCornersKCM.h
+++ b/src/kcm/ShapeCornersKCM.h
@@ -12,6 +12,7 @@ public:
 
 public slots:
     void save() override;
+    void update_colors();
 
 private:
     Ui::Form *ui;

--- a/src/kcm/ShapeCornersKCM.ui
+++ b/src/kcm/ShapeCornersKCM.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>390</height>
+    <width>658</width>
+    <height>494</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -19,97 +19,267 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout_4">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Roundness Radius</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QSlider" name="kcfg_Size">
-       <property name="minimum">
-        <number>1</number>
-       </property>
-       <property name="maximum">
-        <number>50</number>
-       </property>
-       <property name="pageStep">
-        <number>1</number>
-       </property>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QGroupBox" name="outlineGroupBox">
+      <widget class="QGroupBox" name="activeBox">
        <property name="title">
-        <string>Outline</string>
+        <string>Active Window</string>
        </property>
-       <property name="flat">
-        <bool>false</bool>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout_2">
+       <layout class="QVBoxLayout" name="verticalLayout">
         <item>
-         <layout class="QFormLayout" name="formLayout">
-          <property name="formAlignment">
-           <set>Qt::AlignHCenter|Qt::AlignTop</set>
-          </property>
+         <layout class="QFormLayout" name="formLayout_7">
           <item row="0" column="0">
-           <widget class="QLabel" name="outlineColorLabel">
+           <widget class="QLabel" name="label_6">
             <property name="text">
-             <string>Active Window Outline Color</string>
+             <string>Corner Roundness Radius</string>
             </property>
            </widget>
           </item>
           <item row="0" column="1">
-           <widget class="KColorButton" name="kcfg_OutlineColor">
-            <property name="alphaChannelEnabled">
-             <bool>true</bool>
-            </property>
-           </widget>
+           <widget class="QDoubleSpinBox" name="kcfg_Size"/>
           </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="thicknessLabel">
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="inactiveBox">
+       <property name="title">
+        <string>Inactive Window</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_3">
+        <item>
+         <layout class="QFormLayout" name="formLayout_6">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_2">
             <property name="text">
-             <string>Thickness</string>
+             <string>Corner Roundness Radius</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
-           <widget class="QDoubleSpinBox" name="kcfg_OutlineThickness">
-            <property name="decimals">
-             <number>1</number>
-            </property>
-            <property name="minimum">
-             <double>0.500000000000000</double>
-            </property>
-            <property name="maximum">
-             <double>10.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>0.500000000000000</double>
-            </property>
-            <property name="value">
-             <double>1.000000000000000</double>
+          <item row="0" column="1">
+           <widget class="QDoubleSpinBox" name="kcfg_InactiveCornerRadius"/>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QGroupBox" name="groupBox">
+       <property name="title">
+        <string>Active Outline</string>
+       </property>
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <item>
+         <layout class="QFormLayout" name="formLayout_9">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_7">
+            <property name="text">
+             <string>Outline Thickness</string>
             </property>
            </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QDoubleSpinBox" name="kcfg_OutlineThickness"/>
           </item>
           <item row="1" column="0">
-           <widget class="QLabel" name="inactiveOutlineColorLabel">
+           <widget class="QLabel" name="label_8">
             <property name="text">
-             <string>Inactive Window Outline Color</string>
+             <string>Outline Transparency</string>
             </property>
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="KColorButton" name="kcfg_InactiveOutlineColor">
-            <property name="alphaChannelEnabled">
+           <widget class="KGradientSelector" name="kcfg_ActiveOutlineAlpha">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>30</width>
+              <height>30</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>30</height>
+             </size>
+            </property>
+            <property name="value">
+             <number>99</number>
+            </property>
+            <property name="maxValue" stdset="0">
+             <number>255</number>
+            </property>
+            <property name="indent">
              <bool>true</bool>
+            </property>
+            <property name="arrowDirection">
+             <enum>Qt::UpArrow</enum>
+            </property>
+            <property name="firstColor">
+             <color alpha="0">
+              <red>0</red>
+              <green>0</green>
+              <blue>0</blue>
+             </color>
+            </property>
+            <property name="secondColor">
+             <color>
+              <red>0</red>
+              <green>0</green>
+              <blue>0</blue>
+             </color>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QComboBox" name="kcfg_ActiveOutlinePalette">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="currentText">
+             <string>Highlight</string>
+            </property>
+            <property name="currentIndex">
+             <number>12</number>
+            </property>
+            <item>
+             <property name="text">
+              <string>WindowText</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Button</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Light</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Midlight</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Dark</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Mid</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Text</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>BrightText</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>ButtonText</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Base</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Window</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Shadow</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Highlight</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>HighlightedText</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Link</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>LinkVisited</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>AlternateBase</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>NoRole</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>ToolTipBase</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>ToolTipText</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>PlaceholderText</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QRadioButton" name="kcfg_ActiveOutlineUsePalette">
+            <property name="text">
+             <string>Use Decoration Color</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="KColorButton" name="kcfg_OutlineColor"/>
+          </item>
+          <item row="3" column="0">
+           <widget class="QRadioButton" name="kcfg_ActiveOutlineUseCustom">
+            <property name="text">
+             <string>Use Custom Color</string>
             </property>
            </widget>
           </item>
@@ -119,81 +289,645 @@
       </widget>
      </item>
      <item>
-      <widget class="QGroupBox" name="shadowsGroupBox">
+      <widget class="QGroupBox" name="groupBox_2">
        <property name="title">
-        <string>Shadows</string>
+        <string>Inactive Outline</string>
        </property>
-       <layout class="QHBoxLayout" name="horizontalLayout">
+       <layout class="QHBoxLayout" name="horizontalLayout_5">
         <item>
-         <layout class="QFormLayout" name="formLayout_2">
-          <property name="formAlignment">
-           <set>Qt::AlignHCenter|Qt::AlignTop</set>
-          </property>
+         <layout class="QFormLayout" name="formLayout_3">
           <item row="0" column="0">
-           <widget class="QLabel" name="activeShadowColorLabel">
+           <widget class="QLabel" name="label_3">
             <property name="text">
-             <string>Active Window Shadow Color</string>
+             <string>Outline Thickness</string>
             </property>
            </widget>
           </item>
           <item row="0" column="1">
-           <widget class="KColorButton" name="kcfg_ShadowColor">
-            <property name="alphaChannelEnabled">
-             <bool>true</bool>
+           <widget class="QDoubleSpinBox" name="kcfg_InactiveOutlineThickness"/>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>Outline Transparency</string>
             </property>
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="QSlider" name="kcfg_ShadowSize">
-            <property name="minimum">
-             <number>1</number>
+           <widget class="KGradientSelector" name="kcfg_InactiveOutlineAlpha">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
             </property>
-            <property name="maximum">
-             <number>50</number>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>30</height>
+             </size>
             </property>
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>30</height>
+             </size>
             </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QSlider" name="kcfg_InactiveShadowSize">
-            <property name="minimum">
-             <number>1</number>
+            <property name="value">
+             <number>99</number>
             </property>
-            <property name="maximum">
-             <number>50</number>
+            <property name="maxValue" stdset="0">
+             <number>255</number>
             </property>
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
+            <property name="indent">
+             <bool>true</bool>
             </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="activeShadowSizeLabel">
-            <property name="text">
-             <string>Active Window Shadow Size</string>
+            <property name="arrowDirection">
+             <enum>Qt::UpArrow</enum>
             </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="inactiveShadowSizeLabel">
-            <property name="text">
-             <string>Inactive Window Shadow Size</string>
+            <property name="firstColor">
+             <color alpha="0">
+              <red>0</red>
+              <green>0</green>
+              <blue>0</blue>
+             </color>
+            </property>
+            <property name="secondColor">
+             <color>
+              <red>0</red>
+              <green>0</green>
+              <blue>0</blue>
+             </color>
             </property>
            </widget>
           </item>
           <item row="2" column="0">
-           <widget class="QLabel" name="inactiveShadowColorLabel">
+           <widget class="QRadioButton" name="kcfg_InactiveOutlineUsePalette">
             <property name="text">
-             <string>Inactive Window Shadow Color</string>
+             <string>Use Decoration Color</string>
             </property>
            </widget>
           </item>
           <item row="2" column="1">
+           <widget class="QComboBox" name="kcfg_InactiveOutlinePalette">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="currentText">
+             <string>Highlight</string>
+            </property>
+            <property name="currentIndex">
+             <number>12</number>
+            </property>
+            <item>
+             <property name="text">
+              <string>WindowText</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Button</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Light</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Midlight</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Dark</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Mid</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Text</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>BrightText</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>ButtonText</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Base</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Window</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Shadow</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Highlight</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>HighlightedText</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Link</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>LinkVisited</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>AlternateBase</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>NoRole</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>ToolTipBase</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>ToolTipText</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>PlaceholderText</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QRadioButton" name="kcfg_InactiveOutlineUseCustom">
+            <property name="text">
+             <string>Use Custom Color</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="KColorButton" name="kcfg_InactiveOutlineColor"/>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <widget class="QGroupBox" name="groupBox_3">
+       <property name="title">
+        <string>Active Shadow</string>
+       </property>
+       <layout class="QHBoxLayout" name="activeShadowBox">
+        <item>
+         <layout class="QFormLayout" name="formLayout_4">
+          <item row="0" column="0">
+           <widget class="QLabel" name="inactiveShadowSizeLabel_2">
+            <property name="text">
+             <string>Shadow Size</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QDoubleSpinBox" name="kcfg_ShadowSize"/>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_9">
+            <property name="text">
+             <string>Initial Transparency</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="KGradientSelector" name="kcfg_ActiveShadowAlpha">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>30</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>30</height>
+             </size>
+            </property>
+            <property name="maximum">
+             <number>255</number>
+            </property>
+            <property name="value">
+             <number>255</number>
+            </property>
+            <property name="arrowDirection">
+             <enum>Qt::UpArrow</enum>
+            </property>
+            <property name="firstColor">
+             <color alpha="0">
+              <red>0</red>
+              <green>0</green>
+              <blue>0</blue>
+             </color>
+            </property>
+            <property name="secondColor">
+             <color>
+              <red>0</red>
+              <green>0</green>
+              <blue>0</blue>
+             </color>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QRadioButton" name="kcfg_ActiveShadowUsePalette">
+            <property name="text">
+             <string>Use Decoration Color</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QComboBox" name="kcfg_ActiveShadowPalette">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="currentText">
+             <string>WindowText</string>
+            </property>
+            <item>
+             <property name="text">
+              <string>WindowText</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Button</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Light</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Midlight</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Dark</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Mid</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Text</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>BrightText</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>ButtonText</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Base</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Window</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Shadow</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Highlight</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>HighlightedText</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Link</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>LinkVisited</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>AlternateBase</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>NoRole</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>ToolTipBase</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>ToolTipText</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>PlaceholderText</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QRadioButton" name="kcfg_ActiveShadowUseCustom">
+            <property name="text">
+             <string>Use Custom Color</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="KColorButton" name="kcfg_ShadowColor">
+            <property name="alphaChannelEnabled">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="groupBox_4">
+       <property name="title">
+        <string>Inactive Shadow</string>
+       </property>
+       <layout class="QHBoxLayout" name="horizontalLayout_7">
+        <item>
+         <layout class="QFormLayout" name="formLayout_5">
+          <item row="0" column="0">
+           <widget class="QLabel" name="inactiveShadowSizeLabel">
+            <property name="text">
+             <string>Shadow Size</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QDoubleSpinBox" name="kcfg_InactiveShadowSize"/>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>Initial Transparency</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="KGradientSelector" name="kcfg_InactiveShadowAlpha">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>30</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>30</height>
+             </size>
+            </property>
+            <property name="maximum">
+             <number>255</number>
+            </property>
+            <property name="value">
+             <number>255</number>
+            </property>
+            <property name="arrowDirection">
+             <enum>Qt::UpArrow</enum>
+            </property>
+            <property name="firstColor">
+             <color alpha="0">
+              <red>0</red>
+              <green>0</green>
+              <blue>0</blue>
+             </color>
+            </property>
+            <property name="secondColor">
+             <color>
+              <red>0</red>
+              <green>0</green>
+              <blue>0</blue>
+             </color>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QRadioButton" name="kcfg_InactiveShadowUsePalette">
+            <property name="text">
+             <string>Use Decoration Color</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QComboBox" name="kcfg_InactiveShadowPalette">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="currentText">
+             <string>WindowText</string>
+            </property>
+            <item>
+             <property name="text">
+              <string>WindowText</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Button</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Light</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Midlight</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Dark</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Mid</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Text</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>BrightText</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>ButtonText</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Base</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Window</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Shadow</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Highlight</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>HighlightedText</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Link</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>LinkVisited</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>AlternateBase</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>NoRole</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>ToolTipBase</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>ToolTipText</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>PlaceholderText</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QRadioButton" name="kcfg_InactiveShadowUseCustom">
+            <property name="text">
+             <string>Use Custom Color</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
            <widget class="KColorButton" name="kcfg_InactiveShadowColor">
             <property name="alphaChannelEnabled">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
            </widget>
           </item>
@@ -204,7 +938,7 @@
      </item>
     </layout>
    </item>
-   <item row="1" column="0">
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -224,6 +958,11 @@
    <class>KColorButton</class>
    <extends>QPushButton</extends>
    <header>kcolorbutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>KGradientSelector</class>
+   <extends>QWidget</extends>
+   <header>kselector.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/options.kcfg
+++ b/src/options.kcfg
@@ -8,6 +8,9 @@
         <entry name="Size" type="UInt">
             <default>10</default>
         </entry>
+        <entry name="InactiveCornerRadius" type="UInt">
+            <default>10</default>
+        </entry>
         <entry name="ShadowSize" type="UInt">
             <default>25</default>
             <min>1</min>
@@ -24,12 +27,75 @@
         </entry>
         <entry name="OutlineThickness" type="Double">
             <default>1</default>
+            <min>0</min>
+            <max>20</max>
+        </entry>
+        <entry name="InactiveOutlineThickness" type="Double">
+            <default>1</default>
+            <min>0</min>
+            <max>20</max>
         </entry>
         <entry name="OutlineColor" type="Color">
             <default>black</default>
         </entry>
         <entry name="InactiveOutlineColor" type="Color">
             <default>black</default>
+        </entry>
+        <entry name="ActiveOutlineAlpha" type="Int">
+            <default>255</default>
+            <min>0</min>
+            <max>255</max>
+        </entry>
+        <entry name="InactiveOutlineAlpha" type="Int">
+            <default>255</default>
+            <min>0</min>
+            <max>255</max>
+        </entry>
+        <entry name="ActiveOutlinePalette" type="UInt">
+            <default>12</default>
+        </entry>
+        <entry name="InactiveOutlinePalette" type="UInt">
+            <default>12</default>
+        </entry>
+        <entry name="ActiveOutlineUsePalette" type="Bool">
+            <default>false</default>
+        </entry>
+        <entry name="InactiveOutlineUsePalette" type="Bool">
+            <default>false</default>
+        </entry>
+        <entry name="ActiveOutlineUseCustom" type="Bool">
+            <default>true</default>
+        </entry>
+        <entry name="InactiveOutlineUseCustom" type="Bool">
+            <default>true</default>
+        </entry>
+        <entry name="ActiveShadowAlpha" type="Int">
+            <default>255</default>
+            <min>0</min>
+            <max>255</max>
+        </entry>
+        <entry name="InactiveShadowAlpha" type="Int">
+            <default>255</default>
+            <min>0</min>
+            <max>255</max>
+        </entry>
+        <entry name="ActiveShadowPalette" type="UInt">
+            <default>11</default>
+        </entry>
+        <entry name="InactiveShadowPalette" type="UInt">
+            <default>11</default>
+        </entry>
+        <entry name="ActiveShadowUsePalette" type="Bool">
+            <default>true</default>
+        </entry>
+        <entry name="InactiveShadowUsePalette" type="Bool">
+            <default>true</default>
+        </entry>
+        <entry name="ActiveShadowUseCustom" type="Bool">
+            <default>false</default>
+        </entry>
+        <entry name="InactiveShadowUseCustom" type="Bool">
+            <default>false</default>
         </entry>
     </group>
 </kcfg>


### PR DESCRIPTION
In this pull request, I completely separate the settings for active and inactive windows. More importantly, I added the ability to choose from KDE Plasma's decoration colours which includes the accent colour.

This is resolving #96 