### PR TITLE
Add prePaintScreen override

### DIFF
--- a/src/ShapeCornersEffect.cpp
+++ b/src/ShapeCornersEffect.cpp
@@ -86,6 +86,17 @@ QRectF operator *(QRectF r, qreal scale) { return {r.x() * scale, r.y() * scale,
 QRect toRect(const QRectF& r) { return {(int)r.x(), (int)r.y(), (int)r.width(), (int)r.height()}; }
 const QRect& toRect(const QRect& r) { return r; }
 
+void ShapeCornersEffect::prePaintScreen(KWin::ScreenPrePaintData &data, std::chrono::milliseconds presentTime) {
+    if (!m_shaderManager.IsValid())
+    {
+        Effect::prePaintScreen(data, presentTime);
+        return;
+    }
+
+    data.paint += data.screen->geometry();
+    Effect::prePaintScreen(data, presentTime);
+}
+
 void ShapeCornersEffect::prePaintWindow(KWin::EffectWindow *w, KWin::WindowPrePaintData &data, std::chrono::milliseconds time)
 {
     if (!hasEffect(w))

--- a/src/ShapeCornersEffect.cpp
+++ b/src/ShapeCornersEffect.cpp
@@ -86,20 +86,9 @@ QRectF operator *(QRectF r, qreal scale) { return {r.x() * scale, r.y() * scale,
 QRect toRect(const QRectF& r) { return {(int)r.x(), (int)r.y(), (int)r.width(), (int)r.height()}; }
 const QRect& toRect(const QRect& r) { return r; }
 
-void ShapeCornersEffect::prePaintScreen(KWin::ScreenPrePaintData &data, std::chrono::milliseconds presentTime) {
-    if (!m_shaderManager.IsValid())
-    {
-        Effect::prePaintScreen(data, presentTime);
-        return;
-    }
-
-    data.paint += data.screen->geometry();
-    Effect::prePaintScreen(data, presentTime);
-}
-
 void ShapeCornersEffect::prePaintWindow(KWin::EffectWindow *w, KWin::WindowPrePaintData &data, std::chrono::milliseconds time)
 {
-    if (!hasEffect(w))
+    if (!hasEffect(w) && !w->isDesktop())
     {
         Effect::prePaintWindow(w, data, time);
         return;

--- a/src/ShapeCornersEffect.h
+++ b/src/ShapeCornersEffect.h
@@ -41,6 +41,7 @@ public:
 
     void reconfigure(ReconfigureFlags flags) override;
 
+    void prePaintScreen(KWin::ScreenPrePaintData &data, std::chrono::milliseconds presentTime) override;
     void prePaintWindow(KWin::EffectWindow *w, KWin::WindowPrePaintData &data, std::chrono::milliseconds time) override;
     void drawWindow(KWin::EffectWindow *window, int mask, const QRegion &region, KWin::WindowPaintData &data) override;
 

--- a/src/ShapeCornersEffect.h
+++ b/src/ShapeCornersEffect.h
@@ -40,8 +40,7 @@ public:
     static bool enabledByDefault() { return supported(); }
 
     void reconfigure(ReconfigureFlags flags) override;
-
-    void prePaintScreen(KWin::ScreenPrePaintData &data, std::chrono::milliseconds presentTime) override;
+    
     void prePaintWindow(KWin::EffectWindow *w, KWin::WindowPrePaintData &data, std::chrono::milliseconds time) override;
     void drawWindow(KWin::EffectWindow *window, int mask, const QRegion &region, KWin::WindowPaintData &data) override;
 


### PR DESCRIPTION
This pull request is a test to resolve issue #98.

My guess is that similar to #37, I had to enlarge the paint area of the desktop. 