### PR TITLE
Include only normal windows

### DIFF
--- a/src/ShapeCornersEffect.cpp
+++ b/src/ShapeCornersEffect.cpp
@@ -175,7 +175,7 @@ bool ShapeCornersEffect::hasEffect(const KWin::EffectWindow *w) const {
     auto name = w->windowClass().split(' ').first();
     return m_shaderManager.IsValid()
            && m_managed.contains(w)
-           && (w->hasDecoration() || ShapeCornersConfig::inclusions().contains(name))
+           && (w->hasDecoration() || (w->isNormalWindow() && ShapeCornersConfig::inclusions().contains(name)))
            && !ShapeCornersConfig::exclusions().contains(name)
            && !isMaximized(w);
 }


### PR DESCRIPTION
When I was using the inclusion list, I was also including all types of windows such as menus. 
This pull request fixes #110 