### PR TITLE
Fix the highlight color change

### DIFF
--- a/src/ShapeCornersShader.cpp
+++ b/src/ShapeCornersShader.cpp
@@ -11,8 +11,7 @@
 #include "ShapeCornersShader.h"
 
 ShapeCornersShader::ShapeCornersShader():
-        m_manager(KWin::ShaderManager::instance()),
-        m_palette(QWidget().palette())
+        m_manager(KWin::ShaderManager::instance())
 {
     const QString shadersDir = IsLegacy()? "kwin/shaders/1.10/": "kwin/shaders/1.40/";
     const QString fragmentshader = QStandardPaths::locate(QStandardPaths::GenericDataLocation, shadersDir + QStringLiteral("shapecorners.frag"));
@@ -59,6 +58,7 @@ bool ShapeCornersShader::IsValid() const {
 const std::unique_ptr<KWin::GLShader>&
 ShapeCornersShader::Bind(KWin::EffectWindow *w) const {
     QColor outlineColor, shadowColor;
+    auto& m_palette = m_widget.palette();
     auto xy = QVector2D((w->frameGeometry().left() - w->expandedGeometry().left()),
                         (w->frameGeometry().top() - w->expandedGeometry().top()));
     m_manager->pushShader(m_shader.get());

--- a/src/ShapeCornersShader.h
+++ b/src/ShapeCornersShader.h
@@ -7,7 +7,7 @@
 
 #include <kwinglutils.h>
 #include <memory>
-#include <QPalette>
+#include <QWidget>
 #include "ShapeCornersConfig.h"
 
 namespace KWin {
@@ -29,7 +29,7 @@ public:
 private:
     std::unique_ptr<KWin::GLShader> m_shader;
     KWin::ShaderManager* m_manager;
-    QPalette m_palette;
+    QWidget m_widget;
     int m_shader_windowSize = 0;
     int m_shader_windowExpandedSize = 0;
     int m_shader_windowTopLeft = 0;


### PR DESCRIPTION
This pull request prevents the need for disabling and enabling the effect to fetch the highlight colors by using a reference to the palette instead of keeping a copy of it.

This fixes #113 