### PR TITLE
Split the tile and maximize checks

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,8 @@ set(effect_SRCS
     ShapeCornersEffect.cpp
     ShapeCornersShader.h
     ShapeCornersShader.cpp
+    ShapeCornersWindow.h
+    ShapeCornersWindow.cpp
     plugin.cpp
 )
 

--- a/src/ShapeCornersEffect.h
+++ b/src/ShapeCornersEffect.h
@@ -22,10 +22,8 @@
 #include "ShapeCornersShader.h"
 
 #if QT_VERSION_MAJOR >= 6
-    #include <effect/effecthandler.h>
     #include <effect/offscreeneffect.h>
 #else
-    #include <kwineffects.h>
     #include <kwinoffscreeneffect.h>
 #endif
 

--- a/src/ShapeCornersEffect.h
+++ b/src/ShapeCornersEffect.h
@@ -38,7 +38,6 @@ public:
 
     static bool supported();
     static bool enabledByDefault() { return supported(); }
-    static bool isWindowActive(const KWin::EffectWindow *w) { return KWin::effects->activeWindow() == w; }
 
     void reconfigure(ReconfigureFlags flags) override;
     void prePaintWindow(KWin::EffectWindow *w, KWin::WindowPrePaintData &data, std::chrono::milliseconds time) override;
@@ -59,14 +58,13 @@ public Q_SLOTS:
 private Q_SLOTS:
     void windowAdded(KWin::EffectWindow *window);
     void windowRemoved(KWin::EffectWindow *window);
-    void windowResized(KWin::EffectWindow *, const QRectF &) { checkTiled(); }
+    void checkMaximized(KWin::EffectWindow *window);
+    void windowResized(KWin::EffectWindow *window, const QRectF &);
 
 private:
-    std::map<const KWin::EffectWindow*, bool> m_managed; // Pair of Window pointers and their maximized/tiled state.
+    std::unordered_map<const KWin::EffectWindow*, ShapeCornersWindow> m_managed; // Pair of Window pointers and their maximized/tiled state.
     ShapeCornersShader m_shaderManager;
 
-    bool hasEffect(const KWin::EffectWindow *w) const;
-    bool isTiled(const KWin::EffectWindow *w) const { return m_managed.at(w); }
     void checkTiled();
     template<bool vertical> bool checkTiled(double window_start, const double& screen_end, double gap = -1);
 };

--- a/src/ShapeCornersShader.cpp
+++ b/src/ShapeCornersShader.cpp
@@ -25,7 +25,7 @@ ShapeCornersShader::ShapeCornersShader():
     if (!m_shader->isValid())
         qCritical() << "ShapeCorners: no valid shaders found! ShapeCorners will not work.";
 
-    m_shader_disableRoundedTile = m_shader->uniformLocation("disableRoundedTile");
+    m_shader_hasRoundCorners = m_shader->uniformLocation("hasRoundCorners");
     m_shader_windowSize = m_shader->uniformLocation("windowSize");
     m_shader_windowExpandedSize = m_shader->uniformLocation("windowExpandedSize");
     m_shader_windowTopLeft = m_shader->uniformLocation("windowTopLeft");
@@ -43,21 +43,21 @@ bool ShapeCornersShader::IsValid() const {
 }
 
 const std::unique_ptr<KWin::GLShader>&
-ShapeCornersShader::Bind(KWin::EffectWindow *w, qreal scale, bool isTiled) const {
+ShapeCornersShader::Bind(const ShapeCornersWindow &window, qreal scale) const {
     QColor outlineColor, shadowColor;
     qreal shadowSize;
     auto& m_palette = m_widget->palette();
-    auto frameGeometry = w->frameGeometry() * scale;
-    auto expandedGeometry = w->expandedGeometry() * scale;
+    auto frameGeometry = window.w->frameGeometry() * scale;
+    auto expandedGeometry = window.w->expandedGeometry() * scale;
     auto xy = QVector2D(frameGeometry.topLeft() - expandedGeometry.topLeft());
     qreal max_shadow_size = xy.length();
     m_manager->pushShader(m_shader.get());
     m_shader->setUniform(m_shader_windowSize, toVector2D(frameGeometry.size()));
     m_shader->setUniform(m_shader_windowExpandedSize, toVector2D(expandedGeometry.size()));
     m_shader->setUniform(m_shader_windowTopLeft, xy);
-    m_shader->setUniform(m_shader_disableRoundedTile, isTiled && ShapeCornersConfig::disableRoundTile());
+    m_shader->setUniform(m_shader_hasRoundCorners, window.hasRoundCorners());
     m_shader->setUniform(m_shader_front, 0);
-    if (ShapeCornersEffect::isWindowActive(w)) {
+    if (window.isActive()) {
         shadowSize = std::min(ShapeCornersConfig::shadowSize() * scale, max_shadow_size);
         m_shader->setUniform(m_shader_radius, static_cast<float>(ShapeCornersConfig::size() * scale));
         m_shader->setUniform(m_shader_outlineThickness, static_cast<float>(ShapeCornersConfig::outlineThickness() * scale));
@@ -68,7 +68,7 @@ ShapeCornersShader::Bind(KWin::EffectWindow *w, qreal scale, bool isTiled) const
         shadowColor = ShapeCornersConfig::activeShadowUsePalette() ?
             m_palette.color(QPalette::Active, static_cast<QPalette::ColorRole>(ShapeCornersConfig::activeShadowPalette())):
             ShapeCornersConfig::shadowColor();
-        outlineColor.setAlpha(isTiled && ShapeCornersConfig::disableOutlineTile() ? 0: ShapeCornersConfig::activeOutlineAlpha());
+        outlineColor.setAlpha(window.hasOutline() ? ShapeCornersConfig::activeOutlineAlpha(): 0);
         shadowColor.setAlpha(ShapeCornersConfig::activeShadowAlpha());
     } else {
         shadowSize = std::min(ShapeCornersConfig::inactiveShadowSize() * scale, max_shadow_size);
@@ -81,7 +81,7 @@ ShapeCornersShader::Bind(KWin::EffectWindow *w, qreal scale, bool isTiled) const
         shadowColor = ShapeCornersConfig::inactiveShadowUsePalette() ?
                       m_palette.color(QPalette::Inactive, static_cast<QPalette::ColorRole>(ShapeCornersConfig::inactiveShadowPalette())):
                       ShapeCornersConfig::inactiveShadowColor();
-        outlineColor.setAlpha(isTiled && ShapeCornersConfig::disableOutlineTile() ? 0: ShapeCornersConfig::inactiveOutlineAlpha());
+        outlineColor.setAlpha(window.hasOutline() ? ShapeCornersConfig::inactiveOutlineAlpha(): 0);
         shadowColor.setAlpha(ShapeCornersConfig::inactiveShadowAlpha());
     }
     m_shader->setUniform(m_shader_shadowSize, static_cast<float>(shadowSize));

--- a/src/ShapeCornersShader.cpp
+++ b/src/ShapeCornersShader.cpp
@@ -3,14 +3,15 @@
 //
 
 #include "ShapeCornersShader.h"
-#include "ShapeCornersEffect.h"
 #include "ShapeCornersConfig.h"
 #include <QFile>
 #include <QWidget>
 
 #if QT_VERSION_MAJOR >= 6
+    #include <effect/effectwindow.h>
     #include <opengl/glutils.h>
 #else
+    #include <kwineffects.h>
     #include <kwinglutils.h>
 #endif
 

--- a/src/ShapeCornersShader.h
+++ b/src/ShapeCornersShader.h
@@ -5,6 +5,8 @@
 #ifndef KWIN4_SHAPECORNERS_CONFIG_SHADERMANAGER_H
 #define KWIN4_SHAPECORNERS_CONFIG_SHADERMANAGER_H
 
+#include "ShapeCornersWindow.h"
+
 #include <qconfig.h>
 #if QT_VERSION_MAJOR >= 6
     #include <effect/effect.h>
@@ -41,7 +43,7 @@ public:
      * \param w The window that the effect will be rendering on
      * \return A reference to the unique pointer of the loaded shader.
      */
-    const std::unique_ptr<KWin::GLShader>& Bind(KWin::EffectWindow *w, qreal scale, bool isTiled) const;
+    const std::unique_ptr<KWin::GLShader>& Bind(const ShapeCornersWindow &window, qreal scale) const;
 
     /**
      * \brief Pop the shader from the stack of rendering.
@@ -90,7 +92,7 @@ private:
      */
     int m_shader_windowTopLeft = 0;
 
-    int m_shader_disableRoundedTile = 0;
+    int m_shader_hasRoundCorners = 0;
 
     /**
      * \brief Reference to `uniform vec4 shadowColor;`

--- a/src/ShapeCornersShader.h
+++ b/src/ShapeCornersShader.h
@@ -6,13 +6,10 @@
 #define KWIN4_SHAPECORNERS_CONFIG_SHADERMANAGER_H
 
 #include "ShapeCornersWindow.h"
+#include <QRectF>
+#include <QVector2D>
 
-#include <qconfig.h>
-#if QT_VERSION_MAJOR >= 6
-    #include <effect/effect.h>
-#else
-    #include <kwineffects.h>
-#endif
+class QWidget;
 
 namespace KWin {
     class GLShader;

--- a/src/ShapeCornersShader.h
+++ b/src/ShapeCornersShader.h
@@ -8,6 +8,7 @@
 #include "ShapeCornersWindow.h"
 #include <QRectF>
 #include <QVector2D>
+#include <memory>
 
 class QWidget;
 

--- a/src/ShapeCornersWindow.cpp
+++ b/src/ShapeCornersWindow.cpp
@@ -29,11 +29,11 @@ bool ShapeCornersWindow::hasEffect() const {
 }
 
 bool ShapeCornersWindow::hasRoundCorners() const {
-    return !(isTiled && ShapeCornersConfig::disableRoundTile())
+    return !(isTiled && ShapeCornersConfig::disableRoundTile() && !isMaximized)
         && !(isMaximized && ShapeCornersConfig::disableRoundMaximize());
 }
 
 bool ShapeCornersWindow::hasOutline() const {
-    return !(isTiled && ShapeCornersConfig::disableOutlineTile())
+    return !(isTiled && ShapeCornersConfig::disableOutlineTile() && !isMaximized)
         && !(isMaximized && ShapeCornersConfig::disableOutlineMaximize());
 }

--- a/src/ShapeCornersWindow.cpp
+++ b/src/ShapeCornersWindow.cpp
@@ -1,0 +1,39 @@
+//
+// Created by matin on 10/04/24.
+//
+
+#include "ShapeCornersWindow.h"
+#include "ShapeCornersConfig.h"
+
+#include <qconfig.h>
+#if QT_VERSION_MAJOR >= 6
+#include <effect/effecthandler.h>
+#else
+#include <kwineffects.h>
+#endif
+
+ShapeCornersWindow::ShapeCornersWindow(KWin::EffectWindow *w, const QString& name)
+        : w(w), name(name)
+{
+}
+
+bool ShapeCornersWindow::isActive() const {
+    return KWin::effects->activeWindow() == w;
+}
+
+bool ShapeCornersWindow::hasEffect() const {
+    return (w->isNormalWindow()
+            || w->isDialog()
+            || ShapeCornersConfig::inclusions().contains(name))
+           && !ShapeCornersConfig::exclusions().contains(name);
+}
+
+bool ShapeCornersWindow::hasRoundCorners() const {
+    return !(isTiled && ShapeCornersConfig::disableRoundTile())
+        && !(isMaximized && ShapeCornersConfig::disableRoundMaximize());
+}
+
+bool ShapeCornersWindow::hasOutline() const {
+    return !(isTiled && ShapeCornersConfig::disableOutlineTile())
+        && !(isMaximized && ShapeCornersConfig::disableOutlineMaximize());
+}

--- a/src/ShapeCornersWindow.h
+++ b/src/ShapeCornersWindow.h
@@ -1,0 +1,30 @@
+//
+// Created by matin on 09/04/24.
+//
+
+#ifndef KWIN4_EFFECT_SHAPECORNERS_SHAPECORNERSWINDOW_H
+#define KWIN4_EFFECT_SHAPECORNERS_SHAPECORNERSWINDOW_H
+
+#include "QString"
+
+namespace KWin
+{
+    class EffectWindow;
+}
+
+struct ShapeCornersWindow
+{
+    KWin::EffectWindow *w;
+    QString name;
+    bool isTiled = false;
+    bool isMaximized = false;
+
+    explicit ShapeCornersWindow(KWin::EffectWindow *w, const QString& name);
+
+    [[nodiscard]] bool isActive() const;
+    [[nodiscard]] bool hasRoundCorners() const;
+    [[nodiscard]] bool hasOutline() const;
+    [[nodiscard]] bool hasEffect() const;
+};
+
+#endif //KWIN4_EFFECT_SHAPECORNERS_SHAPECORNERSWINDOW_H

--- a/src/kcm/ShapeCornersKCM.ui
+++ b/src/kcm/ShapeCornersKCM.ui
@@ -81,14 +81,28 @@
         </layout>
        </item>
        <item>
-        <widget class="QCheckBox" name="kcfg_DisableRoundTile">
-         <property name="text">
-          <string>Disable Roundness on Tile/Maximize</string>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
-        </widget>
+        <layout class="QHBoxLayout" name="horizontalLayout_8">
+         <item>
+          <widget class="QCheckBox" name="kcfg_DisableRoundTile">
+           <property name="text">
+            <string>Disable Roundness on Tile</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="kcfg_DisableRoundMaximize">
+           <property name="text">
+            <string>Disable Roundness on Maximize</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_2">
@@ -527,14 +541,28 @@
         </layout>
        </item>
        <item>
-        <widget class="QCheckBox" name="kcfg_DisableOutlineTile">
-         <property name="text">
-          <string>Disable Outline on Tile/Maximize</string>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
-        </widget>
+        <layout class="QHBoxLayout" name="horizontalLayout_6">
+         <item>
+          <widget class="QCheckBox" name="kcfg_DisableOutlineTile">
+           <property name="text">
+            <string>Disable Outline on Tile</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="kcfg_DisableOutlineMaximize">
+           <property name="text">
+            <string>Disable Outline on Maximize</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_3">

--- a/src/options.kcfg
+++ b/src/options.kcfg
@@ -107,5 +107,11 @@
         <entry name="DisableOutlineTile" type="Bool">
             <default>true</default>
         </entry>
+        <entry name="DisableRoundMaximize" type="Bool">
+            <default>true</default>
+        </entry>
+        <entry name="DisableOutlineMaximize" type="Bool">
+            <default>true</default>
+        </entry>
     </group>
 </kcfg>

--- a/src/shaders/shapecorners.glsl
+++ b/src/shaders/shapecorners.glsl
@@ -1,7 +1,7 @@
 uniform float radius;            // The thickness of the outline in pixels specified in settings.
 uniform vec2 windowSize;         // Containing `window->frameGeometry().size()`
 uniform vec2 windowExpandedSize; // Containing `window->expandedGeometry().size()`
-uniform bool disableRoundedTile;
+uniform bool hasRoundCorners;
 
 uniform vec2 windowTopLeft;      /* The distance between the top-left of `expandedGeometry` and
                                   * the top-left of `frameGeometry`. When `windowTopLeft = {0,0}`, it means
@@ -62,7 +62,7 @@ vec4 shapeCorner(vec2 coord0, vec4 tex, vec2 start, float angle) {
     float distance_from_center;
     vec4 c;
     float r;
-    if (disableRoundedTile) {
+    if (!hasRoundCorners) {
         r = outlineThickness;
         center = start + r * vec2(cos(angle), sin(angle));
         distance_from_center = distance(coord0, center);
@@ -101,7 +101,7 @@ vec4 run(vec4 tex) {
         return tex;
     }
 
-    float r = disableRoundedTile? outlineThickness: radius;
+    float r = hasRoundCorners? radius: outlineThickness;
 
     /* Since `texcoord0` is ranging from {0.0, 0.0} to {1.0, 1.0} is not pixel intuitive,
      * I am changing the range to become from {0.0, 0.0} to {width, height}


### PR DESCRIPTION
In this pull request, I separated the condition of Tile and Maximize checks and included separated checkboxes for disabling the rounding corners or outlines when a window is tiled or maximized.

![image](https://github.com/matinlotfali/KDE-Rounded-Corners/assets/7337168/008ac364-5c85-4ac9-8037-a4f555afe8b9)

This resolves #205 #190 