### PR TITLE
Fix Normal Window Inclusion in Config

### DIFF
--- a/src/kcm/KCM.ui
+++ b/src/kcm/KCM.ui
@@ -1676,7 +1676,7 @@
         </widget>
        </item>
        <item row="1" column="2">
-        <widget class="QCheckBox" name="kcfg_IncludeNormalWindow">
+        <widget class="QCheckBox" name="kcfg_IncludeNormalWindows">
          <property name="text">
           <string>Include all normal windows</string>
          </property>


### PR DESCRIPTION
Embarrassingly, I was missing the plural "s" for the "kcfg_IncludeNormalWindows" widget which makes the connection to the configuration. As a result, the pull request #215 for fixing issue #200  never worked.

This was pointed out in #267 and it should resolve the issue.