### PR TITLE
Don't apply the effect to windows with an invalid size

### DIFF
--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -26,7 +26,8 @@ bool ShapeCorners::Window::isActive() const {
 
 bool ShapeCorners::Window::hasEffect() const {
     return (
-            (
+            w.expandedGeometry().isValid()
+            && (
                     (w.isNormalWindow() && Config::includeNormalWindows())
                     || (w.isDialog() && Config::includeDialogs())
                     || isIncluded


### PR DESCRIPTION
This adds a workaround for #308 and KDE bug [485884](https://bugs.kde.org/show_bug.cgi?id=485884), which are caused by the OffscreenEffect class creating and using a texture with a size of 0x0.

XWayland windows and browsers based on Chromium 132+ may sometimes have a size of 0x0 on Wayland.