### PR TITLE
Fix the issue that windows get included or excluded because they include a working file/directory in their caption

### DIFF
--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -207,5 +207,5 @@ QString ShapeCorners::Window::captionAfterDash() const {
     const auto index = w.caption().indexOf(sep);
     if (index == -1)
         return w.caption();
-    return w.caption().slice(index + sep.size());
+    return w.caption().mid(index + sep.size());
 }

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -173,7 +173,7 @@ void ShapeCorners::Window::configChanged() {
     isIncluded = false;
     for (auto& exclusion: Config::exclusions()) {
         if (w.windowClass().contains(exclusion, Qt::CaseInsensitive)
-            || w.caption().contains(exclusion, Qt::CaseInsensitive)
+            || captionAfterDash().contains(exclusion, Qt::CaseInsensitive)
                 ) {
             isExcluded = true;
 #ifdef DEBUG_INCLUSIONS
@@ -184,7 +184,7 @@ void ShapeCorners::Window::configChanged() {
     }
     for (auto& inclusion: Config::inclusions()) {
         if (w.windowClass().contains(inclusion, Qt::CaseInsensitive)
-            || w.caption().contains(inclusion, Qt::CaseInsensitive)
+            || captionAfterDash().contains(inclusion, Qt::CaseInsensitive)
         ) {
             isIncluded = true;
 #ifdef DEBUG_INCLUSIONS
@@ -200,4 +200,12 @@ QJsonObject ShapeCorners::Window::toJson() const {
     json[QStringLiteral("class")] = w.windowClass();
     json[QStringLiteral("caption")] = w.caption();
     return json;
+}
+
+QString ShapeCorners::Window::captionAfterDash() const {
+    const auto sep = QStringLiteral(" — ");
+    const auto index = w.caption().indexOf(sep);
+    if (index == -1)
+        return w.caption();
+    return w.caption().slice(index + sep.size());
 }

--- a/src/Window.h
+++ b/src/Window.h
@@ -57,6 +57,14 @@ namespace ShapeCorners {
 
         [[nodiscard]] QJsonObject toJson() const;
 
+        /**
+         *  \brief Returns the windows caption after the " — ".
+         *  \description This is useful for apps like Dolphin and Konsole that include the working file/directory in their title
+         *  and we don't want that to be considered in the inclusion and exclusion rules.
+         *  \example a window with the title "file — Dolphin" will have "Dolphin" returned.
+         */
+        [[nodiscard]] QString captionAfterDash() const;
+
     public Q_SLOTS:
         void configChanged();
 


### PR DESCRIPTION
This is to fix #312 for windows that change their titles to include the working file/directory and have the potential to be falsely included or excluded such as Dolphin and Konsole.

This is done by checking the caption after the `" — "` instead of the whole caption.