### PR TITLE
`qdbus-qt6` has been changed to `qdbus6`

### DIFF
--- a/tools/load.sh
+++ b/tools/load.sh
@@ -6,4 +6,4 @@ dbus-send --dest=org.kde.KWin --print-reply /Effects \
   org.kde.kwin.Effects.loadEffect string:kwin4_effect_shapecorners | awk 'NR==2 {print $2}'
 
 kwriteconfig6 --file breezerc --group Common --key OutlineIntensity "OutlineOff"
-qdbus-qt6 org.kde.KWin /KWin reconfigure
+qdbus6 org.kde.KWin /KWin reconfigure

--- a/tools/load.sh
+++ b/tools/load.sh
@@ -6,4 +6,13 @@ dbus-send --dest=org.kde.KWin --print-reply /Effects \
   org.kde.kwin.Effects.loadEffect string:kwin4_effect_shapecorners | awk 'NR==2 {print $2}'
 
 kwriteconfig6 --file breezerc --group Common --key OutlineIntensity "OutlineOff"
-qdbus6 org.kde.KWin /KWin reconfigure
+
+# Find available qdbus binary
+QDBUS_BIN=$(which qdbus6 qdbus-qt6 qdbus 2>/dev/null | head -n 1)
+
+if [ -z "$QDBUS_BIN" ]; then
+    echo "qdbus not found. Exiting."
+    exit 1
+fi
+
+$QDBUS_BIN org.kde.KWin /KWin reconfigure


### PR DESCRIPTION
qdbus-qt6 command not available as of plasma 6.3 it is qdbus6 now.