### PR TITLE
Fix HDR nits for dimmed windows

### DIFF
--- a/src/shaders/shapecorners_qt6.frag
+++ b/src/shaders/shapecorners_qt6.frag
@@ -15,7 +15,12 @@ void main(void)
 
     tex = sourceEncodingToNitsInDestinationColorspace(tex);
     tex = adjustSaturation(tex);
+
+    // to preserve perceptual contrast, apply the inversion in gamma 2.2 space
+    tex = nitsToEncoding(tex, gamma22_EOTF, 0.0, destinationReferenceLuminance);
     tex *= modulation;
+    tex.rgb *= tex.a;
+    tex = encodingToNits(tex, gamma22_EOTF, 0.0, destinationReferenceLuminance);
 
     gl_FragColor = nitsToDestinationEncoding(tex);
 }

--- a/src/shaders/shapecorners_qt6_core.frag
+++ b/src/shaders/shapecorners_qt6_core.frag
@@ -17,7 +17,12 @@ void main(void)
 
     tex = sourceEncodingToNitsInDestinationColorspace(tex);
     tex = adjustSaturation(tex);
+
+    // to preserve perceptual contrast, apply the inversion in gamma 2.2 space
+    tex = nitsToEncoding(tex, gamma22_EOTF, 0.0, destinationReferenceLuminance);
     tex *= modulation;
+    tex.rgb *= tex.a;
+    tex = encodingToNits(tex, gamma22_EOTF, 0.0, destinationReferenceLuminance);
 
     fragColor = nitsToDestinationEncoding(tex);
 }


### PR DESCRIPTION
This is to fix #339.

I noticed this in the most recent code of `invert` effect. 

I don't have an HDR monitor so I need others to test this.