### PR TITLE
Restore the custom shadows alongside the native shadow option.

### DIFF
--- a/.github/workflows/glslangValidator.yml
+++ b/.github/workflows/glslangValidator.yml
@@ -31,6 +31,6 @@ jobs:
     - name: Validate Shaders
       working-directory: src/shaders
       run: |
-        sed -i -e "/#include "shapecorners_shadows.glsl\"/ {' -e 'r shapecorners_shadows.glsl' -e 'd' -e '}' *.frag
+        sed -i -e '/#include "shapecorners_shadows.glsl\"/ {' -e 'r shapecorners_shadows.glsl' -e 'd' -e '}' *.frag
         sed -i -e '/#include "shapecorners.glsl"/ {' -e 'r shapecorners.glsl' -e 'd' -e '}' *.frag        
         glslangValidator *_qt5*.frag

--- a/.github/workflows/glslangValidator.yml
+++ b/.github/workflows/glslangValidator.yml
@@ -31,6 +31,6 @@ jobs:
     - name: Validate Shaders
       working-directory: src/shaders
       run: |
-        sed -i -e '/#include "shapecorners_shadows.glsl\"/ {' -e 'r shapecorners_shadows.glsl' -e 'd' -e '}' *.frag
+        sed -i -e '/#include "shapecorners_shadows.glsl"/ {' -e 'r shapecorners_shadows.glsl' -e 'd' -e '}' *.glsl
         sed -i -e '/#include "shapecorners.glsl"/ {' -e 'r shapecorners.glsl' -e 'd' -e '}' *.frag        
         glslangValidator *_qt5*.frag

--- a/.github/workflows/glslangValidator.yml
+++ b/.github/workflows/glslangValidator.yml
@@ -31,5 +31,6 @@ jobs:
     - name: Validate Shaders
       working-directory: src/shaders
       run: |
-        sed -e '/#include "shapecorners.glsl"/ {' -e 'r shapecorners.glsl' -e 'd' -e '}' -i *.frag        
+        sed -i -e "/#include "shapecorners_shadows.glsl\"/ {' -e 'r shapecorners_shadows.glsl' -e 'd' -e '}' *.frag
+        sed -i -e '/#include "shapecorners.glsl"/ {' -e 'r shapecorners.glsl' -e 'd' -e '}' *.frag        
         glslangValidator *_qt5*.frag

--- a/po/kcmcorners.pot
+++ b/po/kcmcorners.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-12 17:38+0200\n"
+"POT-Creation-Date: 2025-05-25 16:06-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,30 +21,30 @@ msgstr ""
 #. i18n: ectx: property (windowTitle), widget (QWidget, Form)
 #: rc.cpp:3
 #, kde-format
-msgid "Form"
+msgid "Rounded Corners (formerly ShapeCorners)"
 msgstr ""
 
-#. i18n: file: src/kcm/KCM.ui:30
-#. i18n: ectx: attribute (title), widget (QWidget, roundnessTab)
-#: rc.cpp:6
-#, kde-format
-msgid "Roundness"
-msgstr ""
-
-#. i18n: file: src/kcm/KCM.ui:36
+#. i18n: file: src/kcm/KCM.ui:26
 #. i18n: ectx: property (text), widget (QCheckBox, kcfg_AnimationEnabled)
-#: rc.cpp:9
+#: rc.cpp:6
 #, kde-format
 msgid "Enable animation between active and inactive state"
 msgstr ""
 
+#. i18n: file: src/kcm/KCM.ui:40
+#. i18n: ectx: attribute (title), widget (QWidget, roundnessTab)
+#: rc.cpp:9
+#, kde-format
+msgid "Roundness"
+msgstr ""
+
 #. i18n: file: src/kcm/KCM.ui:48
 #. i18n: ectx: property (title), widget (QGroupBox, activeBox)
-#. i18n: file: src/kcm/KCM.ui:145
+#. i18n: file: src/kcm/KCM.ui:669
 #. i18n: ectx: property (title), widget (QGroupBox, groupBox)
-#. i18n: file: src/kcm/KCM.ui:606
+#. i18n: file: src/kcm/KCM.ui:1130
 #. i18n: ectx: property (title), widget (QGroupBox, groupBox_6)
-#: rc.cpp:12 rc.cpp:36 rc.cpp:201
+#: rc.cpp:12 rc.cpp:213 rc.cpp:378
 #, kde-format
 msgid "Active Window"
 msgstr ""
@@ -60,11 +60,11 @@ msgstr ""
 
 #. i18n: file: src/kcm/KCM.ui:71
 #. i18n: ectx: property (title), widget (QGroupBox, inactiveBox)
-#. i18n: file: src/kcm/KCM.ui:368
+#. i18n: file: src/kcm/KCM.ui:892
 #. i18n: ectx: property (title), widget (QGroupBox, groupBox_2)
-#. i18n: file: src/kcm/KCM.ui:829
+#. i18n: file: src/kcm/KCM.ui:1353
 #. i18n: ectx: property (title), widget (QGroupBox, groupBox_5)
-#: rc.cpp:18 rc.cpp:117 rc.cpp:282
+#: rc.cpp:18 rc.cpp:294 rc.cpp:459
 #, kde-format
 msgid "Inactive Window"
 msgstr ""
@@ -83,474 +83,652 @@ msgstr ""
 msgid "Disable Roundness on Maximize"
 msgstr ""
 
-#. i18n: file: src/kcm/KCM.ui:130
-#. i18n: ectx: attribute (title), widget (QWidget, outlineTab)
+#. i18n: file: src/kcm/KCM.ui:116
+#. i18n: ectx: property (text), widget (QCheckBox, kcfg_DisableRoundFullScreen)
 #: rc.cpp:30
 #, kde-format
-msgid "Outlines"
+msgid "Disable Roundness on FullScreen"
 msgstr ""
 
-#. i18n: file: src/kcm/KCM.ui:136
-#. i18n: ectx: property (title), widget (QGroupBox, primaryOutline)
+#. i18n: file: src/kcm/KCM.ui:140
+#. i18n: ectx: attribute (title), widget (QWidget, shadowsTab)
 #: rc.cpp:33
 #, kde-format
-msgid "Primar&y Outline"
+msgid "Shadows"
 msgstr ""
 
-#. i18n: file: src/kcm/KCM.ui:153
-#. i18n: ectx: property (text), widget (QLabel, label_7)
-#. i18n: file: src/kcm/KCM.ui:376
-#. i18n: ectx: property (text), widget (QLabel, label_3)
-#. i18n: file: src/kcm/KCM.ui:614
-#. i18n: ectx: property (text), widget (QLabel, label_14)
-#. i18n: file: src/kcm/KCM.ui:837
-#. i18n: ectx: property (text), widget (QLabel, label_12)
-#: rc.cpp:39 rc.cpp:120 rc.cpp:204 rc.cpp:285
+#. i18n: file: src/kcm/KCM.ui:146
+#. i18n: ectx: property (text), widget (QRadioButton, kcfg_UseNativeDecorationShadows)
+#: rc.cpp:36
 #, kde-format
-msgid "Outline Thickness"
+msgid "Use Native Decoration Shadows"
 msgstr ""
 
-#. i18n: file: src/kcm/KCM.ui:170
-#. i18n: ectx: property (text), widget (QLabel, label_8)
-#. i18n: file: src/kcm/KCM.ui:393
-#. i18n: ectx: property (text), widget (QLabel, label_4)
-#. i18n: file: src/kcm/KCM.ui:631
-#. i18n: ectx: property (text), widget (QLabel, label_15)
-#. i18n: file: src/kcm/KCM.ui:854
-#. i18n: ectx: property (text), widget (QLabel, label_13)
-#: rc.cpp:42 rc.cpp:123 rc.cpp:207 rc.cpp:288
+#. i18n: file: src/kcm/KCM.ui:156
+#. i18n: ectx: property (text), widget (QRadioButton, UseCustomShadows)
+#: rc.cpp:39
 #, kde-format
-msgid "Outline Transparency"
+msgid "Use Custom Shadows"
 msgstr ""
 
-#. i18n: file: src/kcm/KCM.ui:231
-#. i18n: ectx: property (currentText), widget (QComboBox, kcfg_ActiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:298
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:461
-#. i18n: ectx: property (currentText), widget (QComboBox, kcfg_InactiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:528
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:699
-#. i18n: ectx: property (currentText), widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:766
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:922
-#. i18n: ectx: property (currentText), widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:989
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
-#: rc.cpp:45 rc.cpp:84 rc.cpp:129 rc.cpp:168 rc.cpp:213 rc.cpp:252 rc.cpp:294
-#: rc.cpp:333
+#. i18n: file: src/kcm/KCM.ui:168
+#. i18n: ectx: property (title), widget (QGroupBox, activeShadowGroupBox)
+#: rc.cpp:42
 #, kde-format
-msgid "Highlight"
+msgid "Active Shadow"
 msgstr ""
 
-#. i18n: file: src/kcm/KCM.ui:238
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:468
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:706
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:929
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
-#: rc.cpp:48 rc.cpp:132 rc.cpp:216 rc.cpp:297
+#. i18n: file: src/kcm/KCM.ui:176
+#. i18n: ectx: property (text), widget (QLabel, inactiveShadowSizeLabel_2)
+#. i18n: file: src/kcm/KCM.ui:409
+#. i18n: ectx: property (text), widget (QLabel, inactiveShadowSizeLabel)
+#: rc.cpp:45 rc.cpp:126
 #, kde-format
-msgid "WindowText"
+msgid "Shadow Size*"
 msgstr ""
 
-#. i18n: file: src/kcm/KCM.ui:243
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:473
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:711
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:934
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
-#: rc.cpp:51 rc.cpp:135 rc.cpp:219 rc.cpp:300
+#. i18n: file: src/kcm/KCM.ui:190
+#. i18n: ectx: property (text), widget (QLabel, label_9)
+#. i18n: file: src/kcm/KCM.ui:423
+#. i18n: ectx: property (text), widget (QLabel, label_5)
+#: rc.cpp:48 rc.cpp:129
 #, kde-format
-msgid "Button"
+msgid "Initial Transparency"
 msgstr ""
 
 #. i18n: file: src/kcm/KCM.ui:248
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:478
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:716
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:939
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
-#: rc.cpp:54 rc.cpp:138 rc.cpp:222 rc.cpp:303
-#, kde-format
-msgid "Light"
-msgstr ""
-
-#. i18n: file: src/kcm/KCM.ui:253
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:483
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:721
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:944
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
-#: rc.cpp:57 rc.cpp:141 rc.cpp:225 rc.cpp:306
-#, kde-format
-msgid "Midlight"
-msgstr ""
-
-#. i18n: file: src/kcm/KCM.ui:258
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:488
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:726
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:949
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
-#: rc.cpp:60 rc.cpp:144 rc.cpp:228 rc.cpp:309
-#, kde-format
-msgid "Dark"
-msgstr ""
-
-#. i18n: file: src/kcm/KCM.ui:263
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:493
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:731
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:954
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
-#: rc.cpp:63 rc.cpp:147 rc.cpp:231 rc.cpp:312
-#, kde-format
-msgid "Mid"
-msgstr ""
-
-#. i18n: file: src/kcm/KCM.ui:268
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:498
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:736
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:959
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
-#: rc.cpp:66 rc.cpp:150 rc.cpp:234 rc.cpp:315
-#, kde-format
-msgid "Text"
-msgstr ""
-
-#. i18n: file: src/kcm/KCM.ui:273
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:503
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:741
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:964
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
-#: rc.cpp:69 rc.cpp:153 rc.cpp:237 rc.cpp:318
-#, kde-format
-msgid "BrightText"
-msgstr ""
-
-#. i18n: file: src/kcm/KCM.ui:278
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:508
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:746
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:969
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
-#: rc.cpp:72 rc.cpp:156 rc.cpp:240 rc.cpp:321
-#, kde-format
-msgid "ButtonText"
-msgstr ""
-
-#. i18n: file: src/kcm/KCM.ui:283
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:513
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:751
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:974
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
-#: rc.cpp:75 rc.cpp:159 rc.cpp:243 rc.cpp:324
-#, kde-format
-msgid "Base"
-msgstr ""
-
-#. i18n: file: src/kcm/KCM.ui:288
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:518
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:756
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:979
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
-#: rc.cpp:78 rc.cpp:162 rc.cpp:246 rc.cpp:327
-#, kde-format
-msgid "Window"
-msgstr ""
-
-#. i18n: file: src/kcm/KCM.ui:293
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:523
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:761
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:984
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
-#: rc.cpp:81 rc.cpp:165 rc.cpp:249 rc.cpp:330
-#, kde-format
-msgid "Shadow"
-msgstr ""
-
-#. i18n: file: src/kcm/KCM.ui:303
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:533
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:771
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:994
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
-#: rc.cpp:87 rc.cpp:171 rc.cpp:255 rc.cpp:336
-#, kde-format
-msgid "HighlightedText"
-msgstr ""
-
-#. i18n: file: src/kcm/KCM.ui:308
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:538
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:776
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:999
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
-#: rc.cpp:90 rc.cpp:174 rc.cpp:258 rc.cpp:339
-#, kde-format
-msgid "Link"
-msgstr ""
-
-#. i18n: file: src/kcm/KCM.ui:313
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:543
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:781
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:1004
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
-#: rc.cpp:93 rc.cpp:177 rc.cpp:261 rc.cpp:342
-#, kde-format
-msgid "LinkVisited"
-msgstr ""
-
-#. i18n: file: src/kcm/KCM.ui:318
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:548
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:786
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:1009
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
-#: rc.cpp:96 rc.cpp:180 rc.cpp:264 rc.cpp:345
-#, kde-format
-msgid "AlternateBase"
-msgstr ""
-
-#. i18n: file: src/kcm/KCM.ui:323
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:553
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:791
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:1014
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
-#: rc.cpp:99 rc.cpp:183 rc.cpp:267 rc.cpp:348
-#, kde-format
-msgid "NoRole"
-msgstr ""
-
-#. i18n: file: src/kcm/KCM.ui:328
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:558
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:796
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:1019
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
-#: rc.cpp:102 rc.cpp:186 rc.cpp:270 rc.cpp:351
-#, kde-format
-msgid "ToolTipBase"
-msgstr ""
-
-#. i18n: file: src/kcm/KCM.ui:333
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:563
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:801
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:1024
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
-#: rc.cpp:105 rc.cpp:189 rc.cpp:273 rc.cpp:354
-#, kde-format
-msgid "ToolTipText"
-msgstr ""
-
-#. i18n: file: src/kcm/KCM.ui:338
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:568
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:806
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
-#. i18n: file: src/kcm/KCM.ui:1029
-#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
-#: rc.cpp:108 rc.cpp:192 rc.cpp:276 rc.cpp:357
-#, kde-format
-msgid "PlaceholderText"
-msgstr ""
-
-#. i18n: file: src/kcm/KCM.ui:346
+#. i18n: ectx: property (text), widget (QRadioButton, kcfg_ActiveShadowUsePalette)
+#. i18n: file: src/kcm/KCM.ui:870
 #. i18n: ectx: property (text), widget (QRadioButton, kcfg_ActiveOutlineUsePalette)
-#. i18n: file: src/kcm/KCM.ui:686
+#. i18n: file: src/kcm/KCM.ui:1210
 #. i18n: ectx: property (text), widget (QRadioButton, kcfg_ActiveSecondOutlineUsePalette)
-#: rc.cpp:111 rc.cpp:210
+#: rc.cpp:51 rc.cpp:288 rc.cpp:387
 #, kde-format
 msgid "&Use Decoration Color"
 msgstr ""
 
-#. i18n: file: src/kcm/KCM.ui:356
+#. i18n: file: src/kcm/KCM.ui:261
+#. i18n: ectx: property (currentText), widget (QComboBox, kcfg_ActiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:265
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:494
+#. i18n: ectx: property (currentText), widget (QComboBox, kcfg_InactiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:498
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:762
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:992
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1230
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1453
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
+#: rc.cpp:54 rc.cpp:57 rc.cpp:135 rc.cpp:138 rc.cpp:225 rc.cpp:309 rc.cpp:393
+#: rc.cpp:474
+#, kde-format
+msgid "WindowText"
+msgstr ""
+
+#. i18n: file: src/kcm/KCM.ui:270
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:503
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:767
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:997
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1235
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1458
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
+#: rc.cpp:60 rc.cpp:141 rc.cpp:228 rc.cpp:312 rc.cpp:396 rc.cpp:477
+#, kde-format
+msgid "Button"
+msgstr ""
+
+#. i18n: file: src/kcm/KCM.ui:275
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:508
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:772
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1002
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1240
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1463
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
+#: rc.cpp:63 rc.cpp:144 rc.cpp:231 rc.cpp:315 rc.cpp:399 rc.cpp:480
+#, kde-format
+msgid "Light"
+msgstr ""
+
+#. i18n: file: src/kcm/KCM.ui:280
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:513
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:777
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1007
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1245
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1468
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
+#: rc.cpp:66 rc.cpp:147 rc.cpp:234 rc.cpp:318 rc.cpp:402 rc.cpp:483
+#, kde-format
+msgid "Midlight"
+msgstr ""
+
+#. i18n: file: src/kcm/KCM.ui:285
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:518
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:782
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1012
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1250
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1473
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
+#: rc.cpp:69 rc.cpp:150 rc.cpp:237 rc.cpp:321 rc.cpp:405 rc.cpp:486
+#, kde-format
+msgid "Dark"
+msgstr ""
+
+#. i18n: file: src/kcm/KCM.ui:290
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:523
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:787
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1017
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1255
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1478
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
+#: rc.cpp:72 rc.cpp:153 rc.cpp:240 rc.cpp:324 rc.cpp:408 rc.cpp:489
+#, kde-format
+msgid "Mid"
+msgstr ""
+
+#. i18n: file: src/kcm/KCM.ui:295
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:528
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:792
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1022
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1260
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1483
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
+#: rc.cpp:75 rc.cpp:156 rc.cpp:243 rc.cpp:327 rc.cpp:411 rc.cpp:492
+#, kde-format
+msgid "Text"
+msgstr ""
+
+#. i18n: file: src/kcm/KCM.ui:300
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:533
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:797
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1027
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1265
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1488
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
+#: rc.cpp:78 rc.cpp:159 rc.cpp:246 rc.cpp:330 rc.cpp:414 rc.cpp:495
+#, kde-format
+msgid "BrightText"
+msgstr ""
+
+#. i18n: file: src/kcm/KCM.ui:305
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:538
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:802
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1032
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1270
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1493
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
+#: rc.cpp:81 rc.cpp:162 rc.cpp:249 rc.cpp:333 rc.cpp:417 rc.cpp:498
+#, kde-format
+msgid "ButtonText"
+msgstr ""
+
+#. i18n: file: src/kcm/KCM.ui:310
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:543
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:807
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1037
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1275
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1498
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
+#: rc.cpp:84 rc.cpp:165 rc.cpp:252 rc.cpp:336 rc.cpp:420 rc.cpp:501
+#, kde-format
+msgid "Base"
+msgstr ""
+
+#. i18n: file: src/kcm/KCM.ui:315
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:548
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:812
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1042
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1280
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1503
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
+#: rc.cpp:87 rc.cpp:168 rc.cpp:255 rc.cpp:339 rc.cpp:423 rc.cpp:504
+#, kde-format
+msgid "Window"
+msgstr ""
+
+#. i18n: file: src/kcm/KCM.ui:320
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:553
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:817
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1047
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1285
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1508
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
+#: rc.cpp:90 rc.cpp:171 rc.cpp:258 rc.cpp:342 rc.cpp:426 rc.cpp:507
+#, kde-format
+msgid "Shadow"
+msgstr ""
+
+#. i18n: file: src/kcm/KCM.ui:325
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:558
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:755
+#. i18n: ectx: property (currentText), widget (QComboBox, kcfg_ActiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:822
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:985
+#. i18n: ectx: property (currentText), widget (QComboBox, kcfg_InactiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1052
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1223
+#. i18n: ectx: property (currentText), widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1290
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1446
+#. i18n: ectx: property (currentText), widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1513
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
+#: rc.cpp:93 rc.cpp:174 rc.cpp:222 rc.cpp:261 rc.cpp:306 rc.cpp:345 rc.cpp:390
+#: rc.cpp:429 rc.cpp:471 rc.cpp:510
+#, kde-format
+msgid "Highlight"
+msgstr ""
+
+#. i18n: file: src/kcm/KCM.ui:330
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:563
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:827
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1057
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1295
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1518
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
+#: rc.cpp:96 rc.cpp:177 rc.cpp:264 rc.cpp:348 rc.cpp:432 rc.cpp:513
+#, kde-format
+msgid "HighlightedText"
+msgstr ""
+
+#. i18n: file: src/kcm/KCM.ui:335
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:568
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:832
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1062
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1300
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1523
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
+#: rc.cpp:99 rc.cpp:180 rc.cpp:267 rc.cpp:351 rc.cpp:435 rc.cpp:516
+#, kde-format
+msgid "Link"
+msgstr ""
+
+#. i18n: file: src/kcm/KCM.ui:340
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:573
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:837
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1067
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1305
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1528
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
+#: rc.cpp:102 rc.cpp:183 rc.cpp:270 rc.cpp:354 rc.cpp:438 rc.cpp:519
+#, kde-format
+msgid "LinkVisited"
+msgstr ""
+
+#. i18n: file: src/kcm/KCM.ui:345
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:578
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:842
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1072
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1310
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1533
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
+#: rc.cpp:105 rc.cpp:186 rc.cpp:273 rc.cpp:357 rc.cpp:441 rc.cpp:522
+#, kde-format
+msgid "AlternateBase"
+msgstr ""
+
+#. i18n: file: src/kcm/KCM.ui:350
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:583
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:847
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1077
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1315
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1538
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
+#: rc.cpp:108 rc.cpp:189 rc.cpp:276 rc.cpp:360 rc.cpp:444 rc.cpp:525
+#, kde-format
+msgid "NoRole"
+msgstr ""
+
+#. i18n: file: src/kcm/KCM.ui:355
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:588
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:852
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1082
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1320
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1543
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
+#: rc.cpp:111 rc.cpp:192 rc.cpp:279 rc.cpp:363 rc.cpp:447 rc.cpp:528
+#, kde-format
+msgid "ToolTipBase"
+msgstr ""
+
+#. i18n: file: src/kcm/KCM.ui:360
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:593
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:857
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1087
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1325
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1548
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
+#: rc.cpp:114 rc.cpp:195 rc.cpp:282 rc.cpp:366 rc.cpp:450 rc.cpp:531
+#, kde-format
+msgid "ToolTipText"
+msgstr ""
+
+#. i18n: file: src/kcm/KCM.ui:365
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:598
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveShadowPalette)
+#. i18n: file: src/kcm/KCM.ui:862
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1092
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1330
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_ActiveSecondOutlinePalette)
+#. i18n: file: src/kcm/KCM.ui:1553
+#. i18n: ectx: property (text), item, widget (QComboBox, kcfg_InactiveSecondOutlinePalette)
+#: rc.cpp:117 rc.cpp:198 rc.cpp:285 rc.cpp:369 rc.cpp:453 rc.cpp:534
+#, kde-format
+msgid "PlaceholderText"
+msgstr ""
+
+#. i18n: file: src/kcm/KCM.ui:379
+#. i18n: ectx: property (text), widget (QRadioButton, kcfg_ActiveShadowUseCustom)
+#. i18n: file: src/kcm/KCM.ui:880
 #. i18n: ectx: property (text), widget (QRadioButton, kcfg_ActiveOutlineUseCustom)
-#. i18n: file: src/kcm/KCM.ui:814
+#. i18n: file: src/kcm/KCM.ui:1338
 #. i18n: ectx: property (text), widget (QRadioButton, kcfg_ActiveSecondOutlineUseCustom)
-#: rc.cpp:114 rc.cpp:279
+#: rc.cpp:120 rc.cpp:291 rc.cpp:456
 #, kde-format
 msgid "Use Custom Co&lor"
 msgstr ""
 
-#. i18n: file: src/kcm/KCM.ui:448
+#. i18n: file: src/kcm/KCM.ui:401
+#. i18n: ectx: property (title), widget (QGroupBox, inactiveShadowGroupBox)
+#: rc.cpp:123
+#, kde-format
+msgid "Inactive Shadow"
+msgstr ""
+
+#. i18n: file: src/kcm/KCM.ui:481
+#. i18n: ectx: property (text), widget (QRadioButton, kcfg_InactiveShadowUsePalette)
+#. i18n: file: src/kcm/KCM.ui:972
 #. i18n: ectx: property (text), widget (QRadioButton, kcfg_InactiveOutlineUsePalette)
-#. i18n: file: src/kcm/KCM.ui:909
+#. i18n: file: src/kcm/KCM.ui:1433
 #. i18n: ectx: property (text), widget (QRadioButton, kcfg_InactiveSecondOutlineUsePalette)
-#: rc.cpp:126 rc.cpp:291
+#: rc.cpp:132 rc.cpp:303 rc.cpp:468
 #, kde-format
 msgid "Use Decoration Color"
 msgstr ""
 
-#. i18n: file: src/kcm/KCM.ui:576
+#. i18n: file: src/kcm/KCM.ui:612
+#. i18n: ectx: property (text), widget (QRadioButton, kcfg_InactiveShadowUseCustom)
+#. i18n: file: src/kcm/KCM.ui:1100
 #. i18n: ectx: property (text), widget (QRadioButton, kcfg_InactiveOutlineUseCustom)
-#. i18n: file: src/kcm/KCM.ui:1037
+#. i18n: file: src/kcm/KCM.ui:1561
 #. i18n: ectx: property (text), widget (QRadioButton, kcfg_InactiveSecondOutlineUseCustom)
-#: rc.cpp:195 rc.cpp:360
+#: rc.cpp:201 rc.cpp:372 rc.cpp:537
 #, kde-format
 msgid "Use Custom Color"
 msgstr ""
 
-#. i18n: file: src/kcm/KCM.ui:594
-#. i18n: ectx: property (title), widget (QGroupBox, secondaryOutline)
-#: rc.cpp:198
+#. i18n: file: src/kcm/KCM.ui:646
+#. i18n: ectx: property (text), widget (QLabel, label_16)
+#: rc.cpp:204
 #, kde-format
-msgid "Secondary Outline"
+msgid "* Limited by the decoration expanded geometry"
 msgstr ""
 
-#. i18n: file: src/kcm/KCM.ui:1055
+#. i18n: file: src/kcm/KCM.ui:654
+#. i18n: ectx: attribute (title), widget (QWidget, outlineTab)
+#: rc.cpp:207
+#, kde-format
+msgid "Outlines"
+msgstr ""
+
+#. i18n: file: src/kcm/KCM.ui:660
+#. i18n: ectx: property (title), widget (QGroupBox, primaryOutline)
+#: rc.cpp:210
+#, kde-format
+msgid "Primar&y Outline"
+msgstr ""
+
+#. i18n: file: src/kcm/KCM.ui:677
+#. i18n: ectx: property (text), widget (QLabel, label_7)
+#. i18n: file: src/kcm/KCM.ui:900
+#. i18n: ectx: property (text), widget (QLabel, label_3)
+#. i18n: file: src/kcm/KCM.ui:1138
+#. i18n: ectx: property (text), widget (QLabel, label_14)
+#. i18n: file: src/kcm/KCM.ui:1361
+#. i18n: ectx: property (text), widget (QLabel, label_12)
+#: rc.cpp:216 rc.cpp:297 rc.cpp:381 rc.cpp:462
+#, kde-format
+msgid "Outline Thickness"
+msgstr ""
+
+#. i18n: file: src/kcm/KCM.ui:694
+#. i18n: ectx: property (text), widget (QLabel, label_8)
+#. i18n: file: src/kcm/KCM.ui:917
+#. i18n: ectx: property (text), widget (QLabel, label_4)
+#. i18n: file: src/kcm/KCM.ui:1155
+#. i18n: ectx: property (text), widget (QLabel, label_15)
+#. i18n: file: src/kcm/KCM.ui:1378
+#. i18n: ectx: property (text), widget (QLabel, label_13)
+#: rc.cpp:219 rc.cpp:300 rc.cpp:384 rc.cpp:465
+#, kde-format
+msgid "Outline Transparency"
+msgstr ""
+
+#. i18n: file: src/kcm/KCM.ui:1118
+#. i18n: ectx: property (title), widget (QGroupBox, secondaryOutline)
+#: rc.cpp:375
+#, kde-format
+msgid "Secondary Outline*"
+msgstr ""
+
+#. i18n: file: src/kcm/KCM.ui:1579
 #. i18n: ectx: property (text), widget (QCheckBox, kcfg_DisableOutlineTile)
-#: rc.cpp:363
+#: rc.cpp:540
 #, kde-format
 msgid "Disable Outline on Tile"
 msgstr ""
 
-#. i18n: file: src/kcm/KCM.ui:1065
+#. i18n: file: src/kcm/KCM.ui:1589
 #. i18n: ectx: property (text), widget (QCheckBox, kcfg_DisableOutlineMaximize)
-#: rc.cpp:366
+#: rc.cpp:543
 #, kde-format
 msgid "Disable Outline on Maximize"
 msgstr ""
 
-#. i18n: file: src/kcm/KCM.ui:1089
+#. i18n: file: src/kcm/KCM.ui:1599
+#. i18n: ectx: property (text), widget (QCheckBox, kcfg_DisableOutlineFullScreen)
+#: rc.cpp:546
+#, kde-format
+msgid "Disable Outline on FullScreen"
+msgstr ""
+
+#. i18n: file: src/kcm/KCM.ui:1622
+#. i18n: ectx: property (text), widget (QLabel, label_17)
+#: rc.cpp:549
+#, kde-format
+msgid "* Only if the decoration provides expanded geometry"
+msgstr ""
+
+#. i18n: file: src/kcm/KCM.ui:1630
 #. i18n: ectx: attribute (title), widget (QWidget, inclusionsTab)
-#: rc.cpp:369
+#: rc.cpp:552
 #, kde-format
 msgid "Inclusions && Exclusions"
 msgstr ""
 
-#. i18n: file: src/kcm/KCM.ui:1101
+#. i18n: file: src/kcm/KCM.ui:1642
 #. i18n: ectx: property (text), widget (QPushButton, includeButton)
-#: rc.cpp:372
+#: rc.cpp:555
 #, kde-format
 msgid "Include >"
 msgstr ""
 
-#. i18n: file: src/kcm/KCM.ui:1108
+#. i18n: file: src/kcm/KCM.ui:1649
 #. i18n: ectx: property (text), widget (QCheckBox, kcfg_IncludeDialogs)
-#: rc.cpp:375
+#: rc.cpp:558
 #, kde-format
 msgid "Include all dialogs"
 msgstr ""
 
-#. i18n: file: src/kcm/KCM.ui:1124
+#. i18n: file: src/kcm/KCM.ui:1665
 #. i18n: ectx: property (text), widget (QLabel, label_11)
-#: rc.cpp:378
+#: rc.cpp:561
 #, kde-format
 msgid "Excluded Windows:"
 msgstr ""
 
-#. i18n: file: src/kcm/KCM.ui:1137
+#. i18n: file: src/kcm/KCM.ui:1678
 #. i18n: ectx: property (text), widget (QPushButton, deleteIncludeButton)
-#. i18n: file: src/kcm/KCM.ui:1254
+#. i18n: file: src/kcm/KCM.ui:1795
 #. i18n: ectx: property (text), widget (QPushButton, deleteExcludeButton)
-#: rc.cpp:381 rc.cpp:396
+#: rc.cpp:564 rc.cpp:579
 #, kde-format
 msgid "<"
 msgstr ""
 
-#. i18n: file: src/kcm/KCM.ui:1199
+#. i18n: file: src/kcm/KCM.ui:1740
 #. i18n: ectx: property (text), widget (QLabel, label)
-#: rc.cpp:384
+#: rc.cpp:567
 #, kde-format
 msgid "List of Current Open Windows:"
 msgstr ""
 
-#. i18n: file: src/kcm/KCM.ui:1212
+#. i18n: file: src/kcm/KCM.ui:1753
 #. i18n: ectx: property (text), widget (QPushButton, excludeButton)
-#: rc.cpp:387
+#: rc.cpp:570
 #, kde-format
 msgid "Exclude >"
 msgstr ""
 
-#. i18n: file: src/kcm/KCM.ui:1231
+#. i18n: file: src/kcm/KCM.ui:1772
 #. i18n: ectx: property (text), widget (QLabel, label_10)
-#: rc.cpp:390
+#: rc.cpp:573
 #, kde-format
 msgid "Included Windows:"
 msgstr ""
 
-#. i18n: file: src/kcm/KCM.ui:1238
+#. i18n: file: src/kcm/KCM.ui:1779
 #. i18n: ectx: property (text), widget (QCheckBox, kcfg_IncludeNormalWindows)
-#: rc.cpp:393
+#: rc.cpp:576
 #, kde-format
 msgid "Include all normal windows"
 msgstr ""
 
-#. i18n: file: src/kcm/KCM.ui:1313
+#. i18n: file: src/kcm/KCM.ui:1854
 #. i18n: ectx: property (text), widget (QTableWidget, currentWindowList)
-#: rc.cpp:399
+#: rc.cpp:582
 #, kde-format
 msgid "Class 1"
 msgstr ""
 
-#. i18n: file: src/kcm/KCM.ui:1318
+#. i18n: file: src/kcm/KCM.ui:1859
 #. i18n: ectx: property (text), widget (QTableWidget, currentWindowList)
-#: rc.cpp:402
+#: rc.cpp:585
 #, kde-format
 msgid "Class 2"
 msgstr ""
 
-#. i18n: file: src/kcm/KCM.ui:1323
+#. i18n: file: src/kcm/KCM.ui:1864
 #. i18n: ectx: property (text), widget (QTableWidget, currentWindowList)
-#: rc.cpp:405
+#: rc.cpp:588
 #, kde-format
 msgid "Caption"
 msgstr ""
 
-#. i18n: file: src/kcm/KCM.ui:1337
+#. i18n: file: src/kcm/KCM.ui:1878
 #. i18n: ectx: property (text), widget (QPushButton, refreshButton)
-#: rc.cpp:408
+#: rc.cpp:591
 #, kde-format
 msgid "Refresh"
 msgstr ""

--- a/src/Shader.cpp
+++ b/src/Shader.cpp
@@ -4,6 +4,7 @@
 
 #include "Shader.h"
 #include "Window.h"
+#include "Config.h"
 #include <QFile>
 #include <QStandardPaths>
 
@@ -31,6 +32,9 @@ ShapeCorners::Shader::Shader():
     m_shader_windowSize = m_shader->uniformLocation("windowSize");
     m_shader_windowExpandedSize = m_shader->uniformLocation("windowExpandedSize");
     m_shader_windowTopLeft = m_shader->uniformLocation("windowTopLeft");
+    m_shader_usesNativeShadows = m_shader->uniformLocation("usesNativeShadows");
+    m_shader_shadowColor = m_shader->uniformLocation("shadowColor");
+    m_shader_shadowSize = m_shader->uniformLocation("shadowSize");
     m_shader_radius = m_shader->uniformLocation("radius");
     m_shader_outlineColor = m_shader->uniformLocation("outlineColor");
     m_shader_outlineThickness = m_shader->uniformLocation("outlineThickness");
@@ -44,21 +48,27 @@ bool ShapeCorners::Shader::IsValid() const {
     return m_shader && m_shader->isValid();
 }
 
-void ShapeCorners::Shader::Bind(const ShapeCorners::Window &window, qreal scale) const {
-    auto frameGeometry = window.w.frameGeometry() * scale;
-    auto expandedGeometry = window.w.expandedGeometry() * scale;
-    auto xy = QVector2D(frameGeometry.topLeft() - expandedGeometry.topLeft());
+void ShapeCorners::Shader::Bind(const Window &window, const qreal scale) const {
+    const auto frameGeometry = window.w.frameGeometry() * scale;
+    const auto expandedGeometry = window.w.expandedGeometry() * scale;
+    const auto xy = QVector2D(frameGeometry.topLeft() - expandedGeometry.topLeft());
+    const qreal max_shadow_size = xy.length();
+    const auto shadowSize = std::min(window.shadowSize * scale, max_shadow_size);
+
     m_manager->pushShader(m_shader.get());
     m_shader->setUniform(m_shader_windowSize, toVector2D(frameGeometry.size()));
     m_shader->setUniform(m_shader_windowExpandedSize, toVector2D(expandedGeometry.size()));
     m_shader->setUniform(m_shader_windowTopLeft, xy);
     m_shader->setUniform(m_shader_hasRoundCorners, window.hasRoundCorners());
+    m_shader->setUniform(m_shader_usesNativeShadows, Config::useNativeDecorationShadows());
     m_shader->setUniform(m_shader_front, 0);
     m_shader->setUniform(m_shader_radius, static_cast<float>(window.cornerRadius * scale));
     m_shader->setUniform(m_shader_outlineThickness, static_cast<float>(window.outlineSize * scale));
     m_shader->setUniform(m_shader_secondOutlineThickness, static_cast<float>(window.secondOutlineSize * scale));
+    m_shader->setUniform(m_shader_shadowSize, static_cast<float>(shadowSize));
     m_shader->setUniform(m_shader_outlineColor, window.outlineColor.toQColor());
     m_shader->setUniform(m_shader_secondOutlineColor, window.secondOutlineColor.toQColor());
+    m_shader->setUniform(m_shader_shadowColor, window.shadowColor.toQColor());
 }
 
 void ShapeCorners::Shader::Unbind() const {

--- a/src/Shader.h
+++ b/src/Shader.h
@@ -5,6 +5,7 @@
 #ifndef KWIN4_EFFECT_SHAPECORNERS_SHADER_H
 #define KWIN4_EFFECT_SHAPECORNERS_SHADER_H
 
+#include <QRectF> // for KWin 5.27 compatibility
 #include <QVector2D>
 #include <memory>
 

--- a/src/Shader.h
+++ b/src/Shader.h
@@ -5,7 +5,6 @@
 #ifndef KWIN4_EFFECT_SHAPECORNERS_SHADER_H
 #define KWIN4_EFFECT_SHAPECORNERS_SHADER_H
 
-#include <QRectF>
 #include <QVector2D>
 #include <memory>
 
@@ -46,7 +45,8 @@ namespace ShapeCorners {
          * \brief This function assigns the required variables to the shader.
          *        Then it pushes the shader to the stack of rendering.
          *        This needs to be called before each window is rendered.
-         * \param w The window that the effect will be rendering on
+         * \param window The window that the effect will be rendering on
+         * \param scale The scale of the screen
          */
         void Bind(const ShapeCorners::Window &window, qreal scale) const;
 
@@ -92,6 +92,10 @@ namespace ShapeCorners {
          */
         int m_shader_windowTopLeft = 0;
 
+        /**
+         * \brief Reference to `uniform bool hasRoundCorners;`
+         *        Whether the window has rounded corners.
+         */
         int m_shader_hasRoundCorners = 0;
 
         /**
@@ -99,6 +103,24 @@ namespace ShapeCorners {
          *        Containing the corner radius in pixels specified in settings.
          */
         int m_shader_radius = 0;
+
+        /**
+         * \brief Reference to `uniform bool usesNativeShadows;`
+         *        Whether the window has custom shadows.
+         */
+        int m_shader_usesNativeShadows = 0;
+
+        /**
+         * \brief Reference to `uniform vec4 shadowColor;`
+         *        Containing the RGBA of the shadow color specified in settings.
+         */
+        int m_shader_shadowColor = 0;
+
+        /**
+         * \brief Reference to `uniform float shadowSize;`
+         *        Containing the shadow size specified in settings.
+         */
+        int m_shader_shadowSize = 0;
 
         /**
          * \brief Reference to `uniform vec4 outlineColor;`

--- a/src/Window.h
+++ b/src/Window.h
@@ -19,8 +19,8 @@ namespace KWin
     class EffectWindow;
 
 #ifdef QT_DEBUG
-    QDebug operator<<(QDebug& debug, const KWin::EffectWindow& w);
-    inline QDebug operator<<(QDebug& debug, const KWin::EffectWindow* w) { return (debug << *w); }
+    QDebug operator<<(QDebug& debug, const EffectWindow& w);
+    inline QDebug operator<<(QDebug& debug, const EffectWindow* w) { return (debug << *w); }
 #endif
 }
 
@@ -34,8 +34,10 @@ namespace ShapeCorners {
         bool isMaximized = false;
 
         float cornerRadius = -1;
+        float shadowSize = -1;
         float outlineSize = -1;
         float secondOutlineSize = -1;
+        Color shadowColor = {};
         Color outlineColor = {};
         Color secondOutlineColor = {};
 

--- a/src/kcm/KCM.cpp
+++ b/src/kcm/KCM.cpp
@@ -30,12 +30,14 @@ ShapeCorners::KCM::KCM(QWidget* parent, const QVariantList& args)
         QIcon icon (pix);
         ui->kcfg_ActiveOutlinePalette->setItemIcon(index, icon);
         ui->kcfg_ActiveSecondOutlinePalette->setItemIcon(index, icon);
+        ui->kcfg_ActiveShadowPalette->setItemIcon(index, icon);
 
         c = palette().color(QPalette::Inactive, static_cast<QPalette::ColorRole>(index));
         pix.fill(c);
         QIcon icon2 (pix);
         ui->kcfg_InactiveOutlinePalette->setItemIcon(index, icon2);
         ui->kcfg_InactiveSecondOutlinePalette->setItemIcon(index, icon2);
+        ui->kcfg_InactiveShadowPalette->setItemIcon(index, icon2);
     }
 
     connect(ui->kcfg_ActiveOutlinePalette, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &KCM::update_colors);
@@ -52,8 +54,23 @@ ShapeCorners::KCM::KCM(QWidget* parent, const QVariantList& args)
     connect(ui->kcfg_ActiveSecondOutlineUsePalette, &QRadioButton::toggled, this, &KCM::update_colors);
     connect(ui->kcfg_InactiveSecondOutlineUsePalette, &QRadioButton::toggled, this, &KCM::update_colors);
 
+    connect(ui->kcfg_ActiveShadowPalette, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &KCM::update_colors);
+    connect(ui->kcfg_ActiveShadowPalette, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &KCM::update_colors);
+    connect(ui->kcfg_ShadowColor, &KColorButton::changed, this, &KCM::update_colors);
+    connect(ui->kcfg_InactiveShadowColor, &KColorButton::changed, this, &KCM::update_colors);
+    connect(ui->kcfg_ActiveShadowUsePalette, &QRadioButton::toggled, this, &KCM::update_colors);
+    connect(ui->kcfg_InactiveShadowUsePalette, &QRadioButton::toggled, this, &KCM::update_colors);
+    connect(ui->kcfg_UseNativeDecorationShadows, &QRadioButton::toggled, [=, this] {
+        const auto& useCustomShadows = !ui->kcfg_UseNativeDecorationShadows->isChecked();
+        ui->UseCustomShadows->setChecked(useCustomShadows);
+        ui->activeShadowGroupBox->setEnabled(useCustomShadows);
+        ui->inactiveShadowGroupBox->setEnabled(useCustomShadows);
+    });
+
     // It was expected that the Apply button would get enabled automatically as the gradient sliders move, but it doesn't.
     // Maybe it is a bug on the KCM side. Need to check and delete these lines later.
+    connect(ui->kcfg_ActiveShadowAlpha, &KGradientSelector::sliderMoved, this, &KCM::markAsChanged);
+    connect(ui->kcfg_InactiveShadowAlpha, &KGradientSelector::sliderMoved, this, &KCM::markAsChanged);
     connect(ui->kcfg_ActiveOutlineAlpha, &KGradientSelector::sliderMoved, this, &KCM::markAsChanged);
     connect(ui->kcfg_InactiveOutlineAlpha, &KGradientSelector::sliderMoved, this, &KCM::markAsChanged);
     connect(ui->kcfg_ActiveSecondOutlineAlpha, &KGradientSelector::sliderMoved, this, &KCM::markAsChanged);
@@ -141,6 +158,16 @@ void ShapeCorners::KCM::update_colors() {
     index = ui->kcfg_InactiveSecondOutlinePalette->currentIndex();
     color = checked ? palette().color(QPalette::Inactive, static_cast<QPalette::ColorRole>(index)): ui->kcfg_InactiveSecondOutlineColor->color();
     ui->kcfg_InactiveSecondOutlineAlpha->setSecondColor(color);
+
+    checked = ui->kcfg_ActiveShadowUsePalette->isChecked();
+    index = ui->kcfg_ActiveShadowPalette->currentIndex();
+    color = checked ? palette().color(QPalette::Active, static_cast<QPalette::ColorRole>(index)): ui->kcfg_ShadowColor->color();
+    ui->kcfg_ActiveShadowAlpha->setSecondColor(color);
+
+    checked = ui->kcfg_InactiveShadowUsePalette->isChecked();
+    index = ui->kcfg_InactiveShadowPalette->currentIndex();
+    color = checked ? palette().color(QPalette::Inactive, static_cast<QPalette::ColorRole>(index)): ui->kcfg_InactiveShadowColor->color();
+    ui->kcfg_InactiveShadowAlpha->setSecondColor(color);
 }
 
 void ShapeCorners::KCM::update_windows() const {

--- a/src/kcm/KCM.ui
+++ b/src/kcm/KCM.ui
@@ -153,7 +153,7 @@
        <item>
         <widget class="QRadioButton" name="UseCustomShadows">
          <property name="text">
-          <string>Use Custom Shadows*</string>
+          <string>Use Custom Shadows</string>
          </property>
         </widget>
        </item>
@@ -173,7 +173,7 @@
               <item row="0" column="0">
                <widget class="QLabel" name="inactiveShadowSizeLabel_2">
                 <property name="text">
-                 <string>Shadow Size</string>
+                 <string>Shadow Size*</string>
                 </property>
                </widget>
               </item>
@@ -406,7 +406,7 @@
               <item row="0" column="0">
                <widget class="QLabel" name="inactiveShadowSizeLabel">
                 <property name="text">
-                 <string>Shadow Size</string>
+                 <string>Shadow Size*</string>
                 </property>
                </widget>
               </item>
@@ -643,7 +643,7 @@
        <item>
         <widget class="QLabel" name="label_16">
          <property name="text">
-          <string>* Only if the decoration provides expanded geometry</string>
+          <string>* Limited by the decoration expanded geometry</string>
          </property>
         </widget>
        </item>

--- a/src/kcm/KCM.ui
+++ b/src/kcm/KCM.ui
@@ -6,20 +6,30 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>658</width>
-    <height>600</height>
+    <width>700</width>
+    <height>670</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>400</width>
-    <height>0</height>
+    <width>700</width>
+    <height>670</height>
    </size>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string>Rounded Corners (formerly ShapeCorners)</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_4">
+   <item>
+    <widget class="QCheckBox" name="kcfg_AnimationEnabled">
+     <property name="text">
+      <string>Enable animation between active and inactive state</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
@@ -30,16 +40,6 @@
        <string>Roundness</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_2">
-       <item>
-        <widget class="QCheckBox" name="kcfg_AnimationEnabled">
-         <property name="text">
-          <string>Enable animation between active and inactive state</string>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout">
          <item>
@@ -132,6 +132,520 @@
           </size>
          </property>
         </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="shadowsTab">
+      <attribute name="title">
+       <string>Shadows</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_7">
+       <item>
+        <widget class="QRadioButton" name="kcfg_UseNativeDecorationShadows">
+         <property name="text">
+          <string>Use Native Decoration Shadows</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="UseCustomShadows">
+         <property name="text">
+          <string>Use Custom Shadows*</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="customShadowsHorizontalLayout">
+         <item>
+          <widget class="QGroupBox" name="activeShadowGroupBox">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="title">
+            <string>Active Shadow</string>
+           </property>
+           <layout class="QHBoxLayout" name="activeShadowBox">
+            <item>
+             <layout class="QFormLayout" name="formLayout_4">
+              <item row="0" column="0">
+               <widget class="QLabel" name="inactiveShadowSizeLabel_2">
+                <property name="text">
+                 <string>Shadow Size</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QDoubleSpinBox" name="kcfg_ShadowSize">
+                <property name="decimals">
+                 <number>0</number>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="label_9">
+                <property name="text">
+                 <string>Initial Transparency</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="KGradientSelector" name="kcfg_ActiveShadowAlpha">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>0</width>
+                  <height>30</height>
+                 </size>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>16777215</width>
+                  <height>30</height>
+                 </size>
+                </property>
+                <property name="maximum">
+                 <number>255</number>
+                </property>
+                <property name="value">
+                 <number>255</number>
+                </property>
+                <property name="arrowDirection">
+                 <enum>Qt::ArrowType::UpArrow</enum>
+                </property>
+                <property name="firstColor">
+                 <color alpha="0">
+                  <red>0</red>
+                  <green>0</green>
+                  <blue>0</blue>
+                 </color>
+                </property>
+                <property name="secondColor">
+                 <color>
+                  <red>0</red>
+                  <green>0</green>
+                  <blue>0</blue>
+                 </color>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QRadioButton" name="kcfg_ActiveShadowUsePalette">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>&amp;Use Decoration Color</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
+               <widget class="QComboBox" name="kcfg_ActiveShadowPalette">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="currentText">
+                 <string>WindowText</string>
+                </property>
+                <item>
+                 <property name="text">
+                  <string>WindowText</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Button</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Light</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Midlight</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Dark</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Mid</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Text</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>BrightText</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>ButtonText</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Base</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Window</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Shadow</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Highlight</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>HighlightedText</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Link</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>LinkVisited</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>AlternateBase</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>NoRole</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>ToolTipBase</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>ToolTipText</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>PlaceholderText</string>
+                 </property>
+                </item>
+               </widget>
+              </item>
+              <item row="3" column="0">
+               <widget class="QRadioButton" name="kcfg_ActiveShadowUseCustom">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>Use Custom Co&amp;lor</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="1">
+               <widget class="KColorButton" name="kcfg_ShadowColor">
+                <property name="alphaChannelEnabled">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="inactiveShadowGroupBox">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="title">
+            <string>Inactive Shadow</string>
+           </property>
+           <layout class="QHBoxLayout" name="horizontalLayout_7">
+            <item>
+             <layout class="QFormLayout" name="formLayout_5">
+              <item row="0" column="0">
+               <widget class="QLabel" name="inactiveShadowSizeLabel">
+                <property name="text">
+                 <string>Shadow Size</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QDoubleSpinBox" name="kcfg_InactiveShadowSize">
+                <property name="decimals">
+                 <number>0</number>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="label_5">
+                <property name="text">
+                 <string>Initial Transparency</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="KGradientSelector" name="kcfg_InactiveShadowAlpha">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>0</width>
+                  <height>30</height>
+                 </size>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>16777215</width>
+                  <height>30</height>
+                 </size>
+                </property>
+                <property name="maximum">
+                 <number>255</number>
+                </property>
+                <property name="value">
+                 <number>255</number>
+                </property>
+                <property name="arrowDirection">
+                 <enum>Qt::ArrowType::UpArrow</enum>
+                </property>
+                <property name="firstColor">
+                 <color alpha="0">
+                  <red>0</red>
+                  <green>0</green>
+                  <blue>0</blue>
+                 </color>
+                </property>
+                <property name="secondColor">
+                 <color>
+                  <red>0</red>
+                  <green>0</green>
+                  <blue>0</blue>
+                 </color>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QRadioButton" name="kcfg_InactiveShadowUsePalette">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>Use Decoration Color</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
+               <widget class="QComboBox" name="kcfg_InactiveShadowPalette">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="currentText">
+                 <string>WindowText</string>
+                </property>
+                <item>
+                 <property name="text">
+                  <string>WindowText</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Button</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Light</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Midlight</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Dark</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Mid</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Text</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>BrightText</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>ButtonText</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Base</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Window</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Shadow</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Highlight</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>HighlightedText</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Link</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>LinkVisited</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>AlternateBase</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>NoRole</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>ToolTipBase</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>ToolTipText</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>PlaceholderText</string>
+                 </property>
+                </item>
+               </widget>
+              </item>
+              <item row="3" column="0">
+               <widget class="QRadioButton" name="kcfg_InactiveShadowUseCustom">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>Use Custom Color</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="1">
+               <widget class="KColorButton" name="kcfg_InactiveShadowColor">
+                <property name="alphaChannelEnabled">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Orientation::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>208</width>
+           <height>500</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_16">
+         <property name="text">
+          <string>* Only if the decoration provides expanded geometry</string>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>
@@ -601,7 +1115,7 @@
        <item>
         <widget class="QGroupBox" name="secondaryOutline">
          <property name="title">
-          <string>Secondary Outline</string>
+          <string>Secondary Outline*</string>
          </property>
          <property name="checkable">
           <bool>true</bool>
@@ -1101,6 +1615,13 @@
           </size>
          </property>
         </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_17">
+         <property name="text">
+          <string>* Only if the decoration provides expanded geometry</string>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>

--- a/src/kcm/options.kcfg
+++ b/src/kcm/options.kcfg
@@ -16,6 +16,56 @@
             <default>true</default>
         </entry>
 
+        <!-- Shadow Options -->
+
+        <entry name="UseNativeDecorationShadows" type="Bool">
+            <default>true</default>
+        </entry>
+        <entry name="ShadowSize" type="UInt">
+            <default>60</default>
+            <min>0</min>
+        </entry>
+        <entry name="InactiveShadowSize" type="UInt">
+            <default>40</default>
+            <min>0</min>
+        </entry>
+        <entry name="ShadowColor" type="Color">
+            <default>black</default>
+        </entry>
+        <entry name="InactiveShadowColor" type="Color">
+            <default>black</default>
+        </entry>
+        <entry name="ActiveShadowAlpha" type="Int">
+            <default>128</default>
+            <min>0</min>
+            <max>255</max>
+        </entry>
+        <entry name="InactiveShadowAlpha" type="Int">
+            <default>64</default>
+            <min>0</min>
+            <max>255</max>
+        </entry>
+        <entry name="ActiveShadowPalette" type="UInt">
+            <default>11</default>
+        </entry>
+        <entry name="InactiveShadowPalette" type="UInt">
+            <default>11</default>
+        </entry>
+        <entry name="ActiveShadowUsePalette" type="Bool">
+            <default>true</default>
+        </entry>
+        <entry name="InactiveShadowUsePalette" type="Bool">
+            <default>true</default>
+        </entry>
+        <entry name="ActiveShadowUseCustom" type="Bool">
+            <default>false</default>
+        </entry>
+        <entry name="InactiveShadowUseCustom" type="Bool">
+            <default>false</default>
+        </entry>
+
+        <!-- Primary Outline Options -->
+
         <entry name="OutlineThickness" type="Double">
             <default>1</default>
             <min>0</min>
@@ -61,6 +111,8 @@
             <default>true</default>
         </entry>
 
+        <!-- Second Outline Options -->
+
         <entry name="SecondOutlineThickness" type="Double">
             <default>0.75</default>
             <min>0</min>
@@ -105,6 +157,8 @@
         <entry name="InactiveSecondOutlineUseCustom" type="Bool">
             <default>true</default>
         </entry>
+
+        <!-- Inclusion and Exclusion Options -->
 
         <entry name="Inclusions" type="StringList">
         </entry>

--- a/src/shaders/CMakeLists.txt
+++ b/src/shaders/CMakeLists.txt
@@ -1,12 +1,15 @@
 set(SOURCE_SHADER "shapecorners_qt${QT_MAJOR_VERSION}.frag")
 set(SOURCE_SHADER_CORE "shapecorners_qt${QT_MAJOR_VERSION}_core.frag")
 
-set(SED_COMMAND sed -e "/#include \"shapecorners.glsl\"/ { r ${CMAKE_SOURCE_DIR}/src/shaders/shapecorners.glsl" -e "d" -e "}")
+set(SED_SHADOWS_COMMAND sed -i -e "/#include \"shapecorners_shadows.glsl\"/ { r ${CMAKE_SOURCE_DIR}/src/shaders/shapecorners_shadows.glsl" -e "d" -e "}")
+set(SED_MERGE_GLSL_COMMAND sed -e "/#include \"shapecorners.glsl\"/ { r ${CMAKE_SOURCE_DIR}/src/shaders/shapecorners.glsl" -e "d" -e "}")
 
 add_custom_target(
     shaders ALL
-    COMMAND ${SED_COMMAND} "${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_SHADER}" > "${CMAKE_CURRENT_BINARY_DIR}/shapecorners.frag"
-    COMMAND ${SED_COMMAND} "${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_SHADER_CORE}" > "${CMAKE_CURRENT_BINARY_DIR}/shapecorners_core.frag"
+    COMMAND ${SED_MERGE_GLSL_COMMAND} "${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_SHADER}" > "${CMAKE_CURRENT_BINARY_DIR}/shapecorners.frag"
+    COMMAND ${SED_MERGE_GLSL_COMMAND} "${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_SHADER_CORE}" > "${CMAKE_CURRENT_BINARY_DIR}/shapecorners_core.frag"
+    COMMAND ${SED_SHADOWS_COMMAND} "${CMAKE_CURRENT_BINARY_DIR}/shapecorners.frag"
+    COMMAND ${SED_SHADOWS_COMMAND} "${CMAKE_CURRENT_BINARY_DIR}/shapecorners_core.frag"
     DEPENDS
         "${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_SHADER}"
         "${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_SHADER_CORE}"

--- a/src/shaders/shapecorners.glsl
+++ b/src/shaders/shapecorners.glsl
@@ -52,7 +52,7 @@ vec4 shapeCorner(vec2 coord0, vec4 tex, vec2 start, float angle, vec4 coord_shad
     float distance_from_center = distance(coord0, roundness_center);
 
     vec4 secondaryOutlineOverlay = mix(coord_shadowColor, secondOutlineColor, secondOutlineColor.a);
-    if (tex.a > 0.1 && hasPrimaryOutline()) {
+    if (tex.a > 0.0 && hasPrimaryOutline()) {
         vec4 outlineOverlay = vec4(mix(tex.rgb, outlineColor.rgb, outlineColor.a), 1.0);
 
         if (outlineThickness > radius && is_within(coord0, outlineStart, start) && !is_within(coord0, roundness_center, start)) {

--- a/src/shaders/shapecorners.glsl
+++ b/src/shaders/shapecorners.glsl
@@ -21,67 +21,10 @@ vec2 pixel_to_tex(vec2 pixelcoord) {
                 1.0-(pixelcoord.y + windowTopLeft.y) / windowExpandedSize.y);
 }
 bool hasExpandedSize() { return windowSize != windowExpandedSize; }
-bool isDrawingShadows() { return hasExpandedSize(); }
 bool hasPrimaryOutline() { return outlineColor.a > 0.0 && outlineThickness > 0.0; }
 bool hasSecondOutline() { return hasExpandedSize() && secondOutlineColor.a > 0.0 && secondOutlineThickness > 0.0; }
 
-/*
- *  \brief This function is used to choose the pixel shadow color based on the XY pixel and corner radius.
- *  \param coord0: The XY point
- *  \param r: The radius of corners in pixel.
- *  \return The RGBA color to be used for the shadow.
- */
-vec4 getShadow(vec2 coord0, float r, vec4 default_tex) {
-    if(!isDrawingShadows()) {
-        return vec4(0.0, 0.0, 0.0, 0.0);
-    }
-
-    float margin_edge = 2.0;
-    float margin_point = margin_edge + 1.0;
-
-    /*
-        Split the window into these sections below. They will have a different center of circle for rounding.
-
-        TL  T   T   TR
-        L   x   x   R
-        L   x   x   R
-        BL  B   B   BR
-    */
-    if (coord0.y >= -margin_edge && coord0.y <= r) {
-        if (coord0.x >= -margin_edge && coord0.x <= r) {
-            vec2 a = vec2(-margin_point, coord0.y+coord0.x+margin_point);
-            vec2 b = vec2(coord0.x+coord0.y+margin_point, -margin_point);
-            vec4 a_color = texture2D(sampler, pixel_to_tex(a));
-            vec4 b_color = texture2D(sampler, pixel_to_tex(b));
-            return mix(a_color, b_color, distance(a, coord0)/distance(a,b));          // Section TL
-
-        } else if (coord0.x <= windowSize.x + margin_edge && coord0.x >= windowSize.x - r) {
-            vec2 a = vec2(windowSize.x+margin_point, coord0.y+(windowSize.x-coord0.x)+margin_point);
-            vec2 b = vec2(coord0.x-coord0.y-margin_point, -margin_point);
-            vec4 a_color = texture2D(sampler, pixel_to_tex(a));
-            vec4 b_color = texture2D(sampler, pixel_to_tex(b));
-            return mix(a_color, b_color, distance(a, coord0)/distance(a,b));          // Section TR
-
-        }
-    }
-    else if (coord0.y <= windowSize.y + margin_edge && coord0.y >= windowSize.y - r) {
-        if (coord0.x >= -margin_edge && coord0.x <= r) {
-            vec2 a = vec2(-margin_point, coord0.y-coord0.x-margin_point);
-            vec2 b = vec2(coord0.x+(windowSize.y-coord0.y)+margin_point, windowSize.y+margin_point);
-            vec4 a_color = texture2D(sampler, pixel_to_tex(a));
-            vec4 b_color = texture2D(sampler, pixel_to_tex(b));
-            return mix(a_color, b_color, distance(a, coord0)/distance(a,b));          // Section BL
-
-        } else if (coord0.x <= windowSize.x + margin_edge && coord0.x >= windowSize.x - r) {
-            vec2 a = vec2(windowSize.x+margin_point, coord0.y-(windowSize.x-coord0.x)-margin_point);
-            vec2 b = vec2(coord0.x-(windowSize.y-coord0.y)-margin_point, windowSize.y+margin_point);
-            vec4 a_color = texture2D(sampler, pixel_to_tex(a));
-            vec4 b_color = texture2D(sampler, pixel_to_tex(b));
-            return mix(a_color, b_color, distance(a, coord0)/distance(a,b));          // Section BR
-        }
-    }
-    return default_tex;
-}
+#include "shapecorners_shadows.glsl"
 
 /*
  *  \brief This function is used to choose the pixel color based on its distance to the center input.

--- a/src/shaders/shapecorners_shadows.glsl
+++ b/src/shaders/shapecorners_shadows.glsl
@@ -30,7 +30,7 @@ vec4 getCustomShadow(vec2 coord0, float r) {
     float shadowShiftX = sqrt(shadowSize);
     float shadowShiftTop = sqrt(shadowSize);
 
-/*
+    /*
         Split the window into these sections below. They will have a different center of circle for rounding.
 
         TL  T   T   TR
@@ -71,7 +71,7 @@ vec4 getNativeShadow(vec2 coord0, float r, vec4 default_tex) {
     float margin_edge = 2.0;
     float margin_point = margin_edge + 1.0;
 
-/*
+    /*
         Split the window into these sections below. They will have a different center of circle for rounding.
 
         TL  T   T   TR

--- a/src/shaders/shapecorners_shadows.glsl
+++ b/src/shaders/shapecorners_shadows.glsl
@@ -1,0 +1,132 @@
+uniform bool usesNativeShadows;
+uniform vec4 shadowColor;        // The RGBA of the shadow color specified in settings.
+uniform float shadowSize;        // The shadow size specified in settings.
+
+bool isDrawingShadows() { return hasExpandedSize() && (usesNativeShadows || shadowColor.a > 0.0); }
+
+float parametricBlend(float t) {
+    float sqt = t * t;
+    return sqt / (2.0 * (sqt - t) + 1.0);
+}
+
+/*
+ *  \brief This function generates the shadow color based on the distance_from_center
+ *  \param coord0: The XY point
+ *  \param center: The origin XY point that is being used as a reference for the center of shadow darkness.
+ *  \return The RGBA color to be used for the shadow.
+ */
+vec4 getShadowByDistance(vec2 coord0, vec2 center) {
+    float distance_from_center = distance(coord0, center);
+    float percent = 1.0 - distance_from_center/shadowSize;
+    percent = clamp(percent, 0.0, 1.0);
+    percent = parametricBlend(percent);
+    if (percent < 0.0) {
+        return vec4(0.0, 0.0, 0.0, 0.0);
+    }
+    return vec4(shadowColor.rgb * shadowColor.a * percent, shadowColor.a * percent);
+}
+
+vec4 getCustomShadow(vec2 coord0, float r) {
+    float shadowShiftX = sqrt(shadowSize);
+    float shadowShiftTop = sqrt(shadowSize);
+
+/*
+        Split the window into these sections below. They will have a different center of circle for rounding.
+
+        TL  T   T   TR
+        L   x   x   R
+        L   x   x   R
+        BL  B   B   BR
+    */
+    if (coord0.y < r + shadowShiftTop) {
+        if (coord0.x < r + shadowShiftX) {
+            return getShadowByDistance(coord0, vec2(r+shadowShiftX, r+shadowShiftTop));               // Section TL
+        } else if (coord0.x > windowSize.x - r - shadowShiftX) {
+            return getShadowByDistance(coord0, vec2(windowSize.x -r-shadowShiftX, r+shadowShiftTop)); // Section TR
+        } else if (coord0.y < 0.0) {
+            return getShadowByDistance(coord0, vec2(coord0.x, r+shadowShiftTop));                     // Section T
+        }
+    }
+    else if (coord0.y > windowSize.y - r) {
+        if (coord0.x < r + shadowShiftX) {
+            return getShadowByDistance(coord0, vec2(r+shadowShiftX, windowSize.y-r));                   // Section BL
+        } else if (coord0.x > windowSize.x - r - shadowShiftX) {
+            return getShadowByDistance(coord0, vec2(windowSize.x -r-shadowShiftX, windowSize.y - r));   // Section BR
+        } else if (coord0.y > windowSize.y) {
+            return getShadowByDistance(coord0, vec2(coord0.x, windowSize.y - r));                       // Section B
+        }
+    }
+    else {
+        if (coord0.x < 0.0) {
+            return getShadowByDistance(coord0, vec2(r+shadowShiftX, coord0.y));                   // Section L
+        } else if (coord0.x > windowSize.x) {
+            return getShadowByDistance(coord0, vec2(windowSize.x -r-shadowShiftX, coord0.y));     // Section R
+        }
+        // For section x, the tex is not changing
+    }
+    return vec4(0.0, 0.0, 0.0, 0.0);
+}
+
+vec4 getNativeShadow(vec2 coord0, float r, vec4 default_tex) {
+    float margin_edge = 2.0;
+    float margin_point = margin_edge + 1.0;
+
+/*
+        Split the window into these sections below. They will have a different center of circle for rounding.
+
+        TL  T   T   TR
+        L   x   x   R
+        L   x   x   R
+        BL  B   B   BR
+    */
+    if (coord0.y >= -margin_edge && coord0.y <= r) {
+        if (coord0.x >= -margin_edge && coord0.x <= r) {
+            vec2 a = vec2(-margin_point, coord0.y+coord0.x+margin_point);
+            vec2 b = vec2(coord0.x+coord0.y+margin_point, -margin_point);
+            vec4 a_color = texture2D(sampler, pixel_to_tex(a));
+        vec4 b_color = texture2D(sampler, pixel_to_tex(b));
+        return mix(a_color, b_color, distance(a, coord0)/distance(a,b));          // Section TL
+
+        } else if (coord0.x <= windowSize.x + margin_edge && coord0.x >= windowSize.x - r) {
+            vec2 a = vec2(windowSize.x+margin_point, coord0.y+(windowSize.x-coord0.x)+margin_point);
+            vec2 b = vec2(coord0.x-coord0.y-margin_point, -margin_point);
+            vec4 a_color = texture2D(sampler, pixel_to_tex(a));
+        vec4 b_color = texture2D(sampler, pixel_to_tex(b));
+        return mix(a_color, b_color, distance(a, coord0)/distance(a,b));          // Section TR
+
+        }
+    }
+    else if (coord0.y <= windowSize.y + margin_edge && coord0.y >= windowSize.y - r) {
+        if (coord0.x >= -margin_edge && coord0.x <= r) {
+            vec2 a = vec2(-margin_point, coord0.y-coord0.x-margin_point);
+            vec2 b = vec2(coord0.x+(windowSize.y-coord0.y)+margin_point, windowSize.y+margin_point);
+            vec4 a_color = texture2D(sampler, pixel_to_tex(a));
+        vec4 b_color = texture2D(sampler, pixel_to_tex(b));
+        return mix(a_color, b_color, distance(a, coord0)/distance(a,b));          // Section BL
+
+        } else if (coord0.x <= windowSize.x + margin_edge && coord0.x >= windowSize.x - r) {
+            vec2 a = vec2(windowSize.x+margin_point, coord0.y-(windowSize.x-coord0.x)-margin_point);
+            vec2 b = vec2(coord0.x-(windowSize.y-coord0.y)-margin_point, windowSize.y+margin_point);
+            vec4 a_color = texture2D(sampler, pixel_to_tex(a));
+        vec4 b_color = texture2D(sampler, pixel_to_tex(b));
+        return mix(a_color, b_color, distance(a, coord0)/distance(a,b));          // Section BR
+        }
+    }
+    return default_tex;
+}
+
+/*
+ *  \brief This function is used to choose the pixel shadow color based on the XY pixel and corner radius.
+ *  \param coord0: The XY point
+ *  \param r: The radius of corners in pixel.
+ *  \return The RGBA color to be used for the shadow.
+ */
+vec4 getShadow(vec2 coord0, float r, vec4 default_tex) {
+    if(!isDrawingShadows()) {
+        return vec4(0.0, 0.0, 0.0, 0.0);
+    } else if (usesNativeShadows) {
+        return getNativeShadow(coord0, r, default_tex);
+    } else {
+        return getCustomShadow(coord0, r);
+    }
+}


### PR DESCRIPTION
This pull request restores the custom shadows as a selectable option alongside the native shadow interpolation.

This should resolve #306 