### PR TITLE
Add support to custom app launchers like "ditto"

### DIFF
--- a/src/Effect.cpp
+++ b/src/Effect.cpp
@@ -89,6 +89,7 @@ ShapeCorners::Effect::windowAdded(KWin::EffectWindow *w)
         QStringLiteral("ksmserver"),
         QStringLiteral("krunner"),
         QStringLiteral("ksplashqml"),
+        QStringLiteral("plasmashell"),
     };
     const auto name = w->windowClass().split(QChar::Space).first();
     if (hardExceptions.contains(name)) {


### PR DESCRIPTION
I learned that some app launchers like "ditto" use the Normal window type instead of AppletPopup. But they are still using the name "plasmashell".

In this pull request, I am adding "plasmashell" to the hard exceptions. This will fix #355 