### PR TITLE
Fix incorrect windows corner radius when opening maximized

### DIFF
--- a/src/Effect.cpp
+++ b/src/Effect.cpp
@@ -265,21 +265,21 @@ void ShapeCorners::Effect::checkTiled() {
 QRegion ShapeCorners::Effect::getRegionWithoutMenus(const QRect& screen_geometry)
 {
     auto screen_region = QRegion(screen_geometry);
-    #ifdef DEBUG_MAXIMIZED
-        qDebug() << "ShapeCorners: screen region" << screen_region;
-    #endif
+#ifdef DEBUG_MAXIMIZED
+    qDebug() << "ShapeCorners: screen region" << screen_region;
+#endif
 
-        // subtract all menus
-        for (const auto &ptr: m_menuBars) {
-    #ifdef DEBUG_MAXIMIZED
-            qDebug() << "ShapeCorners: menu is" << ptr->frameGeometry();
-    #endif
-            screen_region -= ptr->frameGeometry().toRect();
-        }
+    // subtract all menus
+    for (const auto &ptr: m_menuBars) {
+#ifdef DEBUG_MAXIMIZED
+        qDebug() << "ShapeCorners: menu is" << ptr->frameGeometry();
+#endif
+        screen_region -= ptr->frameGeometry().toRect();
+    }
 
-    #ifdef DEBUG_MAXIMIZED
-        qDebug() << "ShapeCorners: screen region without menus" << screen_region;
-    #endif
+#ifdef DEBUG_MAXIMIZED
+    qDebug() << "ShapeCorners: screen region without menus" << screen_region;
+#endif
 
     return screen_region;
 } 

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -22,7 +22,8 @@ inline float clamp(const float value, const float delta, const float config) {
 QWidget ShapeCorners::Window::m_widget {};
 
 ShapeCorners::Window::Window(KWin::EffectWindow& w)
-        : w(w), isIncluded(false), isExcluded(false)
+    : w(w)
+    , cornerRadius(static_cast<float>(Config::inactiveCornerRadius()))
 {
     configChanged();
 }

--- a/src/Window.h
+++ b/src/Window.h
@@ -33,7 +33,7 @@ namespace ShapeCorners {
         bool isTiled = false;
         bool isMaximized = false;
 
-        float cornerRadius = -1;
+        float cornerRadius;
         float shadowSize = -1;
         float outlineSize = -1;
         float secondOutlineSize = -1;
@@ -72,8 +72,8 @@ namespace ShapeCorners {
 
     private:
         std::chrono::milliseconds m_last_time = {};
-        bool isIncluded;
-        bool isExcluded;
+        bool isIncluded = false;
+        bool isExcluded = false;
 
         /**
          * \brief Used only for its `palette()` function which holds the currently active highlight colors.

--- a/tools/show-kwin-logs.sh
+++ b/tools/show-kwin-logs.sh
@@ -1,1 +1,1 @@
-SYSTEMD_COLORS=true journalctl -f | grep --color=never kwin
+SYSTEMD_COLORS=true journalctl -f | grep --color=never ShapeCorners


### PR DESCRIPTION
This is to fix #360 which was caused by using the radius value to improve performance in #349 