### PR TITLE
Add `libdrm-devel` to dependencies for KWin 6.4

### DIFF
--- a/.github/workflows/fedora42.yml
+++ b/.github/workflows/fedora42.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
     - name: Install Dependencies
       run: |
-        dnf -y install cmake gcc-c++ extra-cmake-modules kwin-devel kf6-kconfigwidgets-devel libepoxy-devel kf6-kcmutils-devel kf6-ki18n-devel qt6-qtbase-private-devel wayland-devel 
+        dnf -y install cmake gcc-c++ extra-cmake-modules kwin-devel kf6-kconfigwidgets-devel libepoxy-devel kf6-kcmutils-devel kf6-ki18n-devel qt6-qtbase-private-devel wayland-devel libdrm-devel
         dnf -y install rpm-build git copr-cli jq
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ You need to install development packages for your distribution first:
 
 - Plasma 6 (Fedora 40 and later)
    ```bash
-   sudo dnf install git cmake gcc-c++ extra-cmake-modules kwin-devel kf6-kconfigwidgets-devel libepoxy-devel kf6-kcmutils-devel kf6-ki18n-devel qt6-qtbase-private-devel wayland-devel
+   sudo dnf install git cmake gcc-c++ extra-cmake-modules kwin-devel kf6-kconfigwidgets-devel libepoxy-devel kf6-kcmutils-devel kf6-ki18n-devel qt6-qtbase-private-devel wayland-devel libdrm-devel
    ``` 
 - Plasma 5 (Fedora 39)
    ```bash


### PR DESCRIPTION
I noticed the build error after the KWin 6.4.0 upgrade related to `libdrm` missing. So I am adding it to the Fedora 42 workflow to see if it resolves it.