### PR TITLE
Add README.md instructions and overlay setup script for KDE Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,28 @@ cmake --build . -j
 sudo make install
 ```
 
+> [!Note] 
+>
+> For systems like **KDE Linux** (https://community.kde.org/KDE_Linux) or other immutable distributions that lack tools such as `rpm-ostree`, it is necessary to manually create a user overlay to supplement missing or non-modifiable system paths.
+>
+> First, clone the source code and compile it into a user-owned directory:
+>
+> ```bash
+> git clone https://github.com/matinlotfali/KDE-Rounded-Corners
+> cd KDE-Rounded-Corners
+> mkdir -p build
+> cd build
+> cmake .. -DCMAKE_INSTALL_PREFIX=../install-root
+> cmake --build . -j
+> make install
+> ```
+>
+> Then, deploy the compiled files into a user overlay directory and activate it using `systemd-sysext`. Running
+> ```bash
+> sh ../tools/deploy-to-overlay.sh
+> ```
+> will automate this process.
+
 > [!Note]
 > If you are building for X11, use the command `cmake .. -DKWIN_X11=ON` instead of `cmake ..`
 

--- a/README.md
+++ b/README.md
@@ -183,30 +183,27 @@ cmake --build . -j
 sudo make install
 ```
 
+> [!Note]
+> If you are building for X11, use the command `cmake .. -DKWIN_X11=ON` instead of `cmake ..`
+
 > [!Note] 
 >
-> For systems like **KDE Linux** (https://community.kde.org/KDE_Linux) or other immutable distributions that lack tools such as `rpm-ostree`, it is necessary to manually create a user overlay to supplement missing or non-modifiable system paths.
+> When building for KDE Linux (https://community.kde.org/KDE_Linux) or other immutable distributions that do not provide tools like `rpm-ostree`, you cannot write to system paths such as `/usr`. To deploy a plugin in such environments, you need to build it into a user overlay and activate it using `systemd-sysext`.
 >
-> First, clone the source code and compile it into a user-owned directory:
+> To ensure the plugin is installed under the correct directory layout expected by KWin, use the following command instead of `cmake ..` :
 >
-> ```bash
-> git clone https://github.com/matinlotfali/KDE-Rounded-Corners
-> cd KDE-Rounded-Corners
-> mkdir -p build
-> cd build
-> cmake .. -DCMAKE_INSTALL_PREFIX=../install-root
-> cmake --build . -j
-> make install
 > ```
->
-> Then, deploy the compiled files into a user overlay directory and activate it using `systemd-sysext`. Running
+> cmake .. \
+>   -DCMAKE_INSTALL_PREFIX=~/kde/usr \
+>   -DKDE_INSTALL_PLUGINDIR=lib/qt6/plugins
+> ```
+> 
+> Once built, you can prepare the overlay by placing it under `~/kde` and linking it into `/var/lib/extensions/kde`, where `systemd-sysext` expects extension roots to be located. The following command automates that:
+> 
 > ```bash
 > sh ../tools/deploy-to-overlay.sh
 > ```
-> will automate this process.
-
-> [!Note]
-> If you are building for X11, use the command `cmake .. -DKWIN_X11=ON` instead of `cmake ..`
+> This way, the plugin is installed in a form that `systemd-sysext` can recognize and load, while still preserving the integrity of the immutable root filesystem.
 
 # How to load or unload the effect
 

--- a/README.md
+++ b/README.md
@@ -187,16 +187,15 @@ sudo make install
 > If you are building for X11, use the command `cmake .. -DKWIN_X11=ON` instead of `cmake ..`
 
 > [!Note] 
->
 > When building for KDE Linux (https://community.kde.org/KDE_Linux) or other immutable distributions that do not provide tools like `rpm-ostree`, you cannot write to system paths such as `/usr`. To deploy a plugin in such environments, you need to build it into a user overlay and activate it using `systemd-sysext`.
 >
-> To ensure the plugin is installed under the correct directory layout expected by KWin, use the following command instead of `cmake ..` :
->
+> To ensure the plugin is installed under the correct directory layout expected by KWin, use
 > ```
 > cmake .. \
 >   -DCMAKE_INSTALL_PREFIX=~/kde/usr \
 >   -DKDE_INSTALL_PLUGINDIR=lib/qt6/plugins
 > ```
+> instead of `cmake ..`, and also use `make install` **instead of** `sudo make install`.
 > 
 > Once built, you can prepare the overlay by placing it under `~/kde` and linking it into `/var/lib/extensions/kde`, where `systemd-sysext` expects extension roots to be located. The following command automates that:
 > 

--- a/tools/deploy-to-overlay.sh
+++ b/tools/deploy-to-overlay.sh
@@ -1,28 +1,8 @@
 #!/bin/bash
 set -e
 
-# Remove previously installed files (if any)
-rm -rf ~/kde/usr/lib/qt6/plugins/kwin/effects/plugins/kwin4_effect_shapecorners.so
-rm -rf ~/kde/usr/lib/qt6/plugins/kwin/effects/configs/kwin_shapecorners_config.so
-rm -rf ~/kde/usr/share/kwin/shaders/shapecorners*.frag
-
-# Create required directories
-mkdir -p ~/kde/usr/lib/qt6/plugins/kwin/effects/plugins
-mkdir -p ~/kde/usr/lib/qt6/plugins/kwin/effects/configs
-mkdir -p ~/kde/usr/share/kwin/shaders
-mkdir -p ~/kde/usr/lib/extension-release.d
-
-# Copy built plugins and shader files into overlay
-cp ../install-root/lib/plugins/kwin/effects/plugins/kwin4_effect_shapecorners.so \
-  ~/kde/usr/lib/qt6/plugins/kwin/effects/plugins/
-
-cp ../install-root/lib/plugins/kwin/effects/configs/kwin_shapecorners_config.so \
-  ~/kde/usr/lib/qt6/plugins/kwin/effects/configs/
-
-cp ../install-root/share/kwin/shaders/shapecorners*.frag \
-  ~/kde/usr/share/kwin/shaders/
-
 # Create extension-release descriptor
+mkdir -p ~/kde/usr/lib/extension-release.d
 cp /usr/lib/os-release ~/kde/usr/lib/extension-release.d/extension-release.kde
 sed -i 's%^ID=.*%ID=_any%' ~/kde/usr/lib/extension-release.d/extension-release.kde
 sudo chown root:root ~/kde/usr/lib/extension-release.d/extension-release.kde
@@ -33,6 +13,3 @@ sudo ln -sf ~/kde /var/lib/extensions/kde
 
 sudo systemd-sysext unmerge || true
 sudo systemd-sysext merge
-
-# Clean up install-root
-rm -rf ../install-root

--- a/tools/deploy-to-overlay.sh
+++ b/tools/deploy-to-overlay.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+
+# Remove previously installed files (if any)
+rm -rf ~/kde/usr/lib/qt6/plugins/kwin/effects/plugins/kwin4_effect_shapecorners.so
+rm -rf ~/kde/usr/lib/qt6/plugins/kwin/effects/configs/kwin_shapecorners_config.so
+rm -rf ~/kde/usr/share/kwin/shaders/shapecorners*.frag
+
+# Create required directories
+mkdir -p ~/kde/usr/lib/qt6/plugins/kwin/effects/plugins
+mkdir -p ~/kde/usr/lib/qt6/plugins/kwin/effects/configs
+mkdir -p ~/kde/usr/share/kwin/shaders
+mkdir -p ~/kde/usr/lib/extension-release.d
+
+# Copy built plugins and shader files into overlay
+cp ../install-root/lib/plugins/kwin/effects/plugins/kwin4_effect_shapecorners.so \
+  ~/kde/usr/lib/qt6/plugins/kwin/effects/plugins/
+
+cp ../install-root/lib/plugins/kwin/effects/configs/kwin_shapecorners_config.so \
+  ~/kde/usr/lib/qt6/plugins/kwin/effects/configs/
+
+cp ../install-root/share/kwin/shaders/shapecorners*.frag \
+  ~/kde/usr/share/kwin/shaders/
+
+# Create extension-release descriptor
+cp /usr/lib/os-release ~/kde/usr/lib/extension-release.d/extension-release.kde
+sed -i 's%^ID=.*%ID=_any%' ~/kde/usr/lib/extension-release.d/extension-release.kde
+sudo chown root:root ~/kde/usr/lib/extension-release.d/extension-release.kde
+
+# Link and merge the extension
+sudo mkdir -p /var/lib/extensions
+sudo ln -sf ~/kde /var/lib/extensions/kde
+
+sudo systemd-sysext unmerge || true
+sudo systemd-sysext merge
+
+# Clean up install-root
+rm -rf ../install-root


### PR DESCRIPTION
Using systemd-sysext is currently the recommended and probably the only method for installations on KDE Linux that require access to /usr. 
See: https://community.kde.org/KDE_Linux#systemd-sysext