### PR TITLE
Add Animation class with animation duration config

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,58 @@
+# Generated from CLion C/C++ Code Style settings
+---
+Language: Cpp
+BasedOnStyle: LLVM
+AccessModifierOffset: -4
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true
+AlignOperands: true
+AlignTrailingComments: true
+AlwaysBreakTemplateDeclarations: Yes
+BraceWrapping: 
+  AfterCaseLabel: false
+  AfterClass: false
+  AfterControlStatement: false
+  AfterEnum: false
+  AfterFunction: false
+  AfterNamespace: false
+  AfterStruct: false
+  AfterUnion: false
+  AfterExternBlock: false
+  BeforeCatch: false
+  BeforeElse: false
+  BeforeLambdaBody: false
+  BeforeWhile: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBraces: Linux
+BreakConstructorInitializers: AfterColon
+BreakConstructorInitializersBeforeComma: false
+ColumnLimit: 120
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ContinuationIndentWidth: 8
+IncludeCategories: 
+  - Regex: '^<.*'
+    Priority: 1
+  - Regex: '^".*'
+    Priority: 2
+  - Regex: '.*'
+    Priority: 3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentWidth: 4
+InsertNewlineAtEOF: true
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: All
+SpaceAfterCStyleCast: true
+SpaceAfterTemplateKeyword: false
+SpaceBeforeRangeBasedForLoopColon: false
+SpaceInEmptyParentheses: false
+SpacesInAngles: false
+SpacesInConditionalStatement: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+TabWidth: 4
+...

--- a/ClassDiagram.md
+++ b/ClassDiagram.md
@@ -63,6 +63,16 @@ classDiagram
             windowAdded()
         }
         
+        class Animation {
+            -lastAnimationDuration: long
+            -m_isAnimating: bool
+            -lastActiveWindowChangedTime: time_point
+            -setActiveWindowChanged()
+            +getFrameConfig()
+            +isAnimating()
+            +update()
+        }
+        
         class WindowManager {
             -m_managed: WindowList
             -m_menuBars: MenuBarList
@@ -99,10 +109,8 @@ classDiagram
         class Window {
             isTiled: bool
             isMaximized: bool
-            -m_last_time: miliseconds
             -isIncluded: bool
             -isExcluded: bool
-            animateProperties()
             isActive()
             hasRoundCorners()
             hasOutline()
@@ -110,7 +118,6 @@ classDiagram
             toJson()
             captionAfterDash()
             configChanged()
-            -getExpectedConfig()
         }
         
         class Shader {
@@ -152,7 +159,7 @@ classDiagram
             Size: UInt
             ShadowSize: UInt
             ShadowColor: Color
-            AnimationEnabled: Bool
+            AnimationDuration: UInt
             OutlineThickness: Double
             OutlineColor: Color
             .
@@ -173,13 +180,16 @@ classDiagram
     OffscreenEffect ..> ShaderManager: Uses
 
     OffscreenEffect <|-- Effect: Inherits
+    Effect ..> Animation: Has
     Effect --> Shader: Has
     Effect --> WindowManager: Has
     Shader --> GLShader: Has
     Shader ..> Window: Uses
     Shader ..> ShaderManager: Uses
-    Window --> WindowConfig: Has
+    Animation --> WindowConfig: Has
+    Animation ..> Window: Uses
     Window --> EffectWindow: Manages
+    Window ..> WindowConfig: Uses
     Window ..> Config: Uses
     WindowConfig o-- FloatColor: Contains
     WindowConfig ..> Config: Uses

--- a/src/Animation.cpp
+++ b/src/Animation.cpp
@@ -4,7 +4,11 @@
 
 #include "Animation.h"
 #include <QDebug>
+#if QT_VERSION_MAJOR >= 6
 #include <effect/effecthandler.h>
+#else
+#include <kwineffects.h>
+#endif
 
 #include "Config.h"
 #include "Window.h"

--- a/src/Animation.cpp
+++ b/src/Animation.cpp
@@ -1,0 +1,81 @@
+//
+// Created by matin on 8/3/25.
+//
+
+#include "Animation.h"
+#include <QDebug>
+#include <effect/effecthandler.h>
+
+#include "Config.h"
+#include "Window.h"
+#include "WindowConfig.h"
+
+using namespace std::chrono;
+
+ShapeCorners::Animation::Animation() : lastAnimationDuration(Config::animationDuration())
+{
+    // Initialize animation state.
+    update();
+    // Connect to window activation signal to handle active window changes.
+    connect(KWin::effects, &KWin::EffectsHandler::windowActivated, this,&Animation::setActiveWindowChanged);
+}
+
+void ShapeCorners::Animation::update()
+{
+    // If not animating, skip update.
+    if (!m_isAnimating) {
+        return;
+    }
+
+    // If animation duration is zero, stop animating and set configs to final state.
+    if (lastAnimationDuration == 0) {
+        m_isAnimating = false;
+        qDebug() << "ShapeCorners: Animation ended.";
+        return;
+    }
+
+    // Calculate remaining animation duration.
+    const auto now               = system_clock::now();
+    const auto animationDuration = Config::animationDuration();
+    lastAnimationDuration = animationDuration + duration_cast<milliseconds>(lastActiveWindowChangedTime - now).count();
+
+    // If animation is over, set configs to their final values.
+    if (lastAnimationDuration < 0) {
+        lastAnimationDuration = 0;
+        activeAnimation       = WindowConfig::activeWindowConfig();
+        inactiveAnimation     = WindowConfig::inactiveWindowConfig();
+        return;
+    }
+
+    // Interpolate between active and inactive configs based on animation progress.
+    const auto deltaTime  = static_cast<float>(lastAnimationDuration) / static_cast<float>(animationDuration);
+    const auto configDiff = WindowConfig::activeWindowConfig() - WindowConfig::inactiveWindowConfig();
+    const auto deltaConf  = configDiff * deltaTime;
+
+    activeAnimation   = WindowConfig::activeWindowConfig() - deltaConf;
+    inactiveAnimation = WindowConfig::inactiveWindowConfig() + deltaConf;
+    m_isAnimating     = true;
+}
+
+const ShapeCorners::WindowConfig *ShapeCorners::Animation::getFrameConfig(const Window &window) const
+{
+    // Return the appropriate config based on window activity.
+    return window.isActive() ? &activeAnimation : &inactiveAnimation;
+}
+
+void ShapeCorners::Animation::setActiveWindowChanged(const KWin::EffectWindow *w)
+{
+    qDebug() << "ShapeCorners: Window activated" << *w;
+    // If not animating, start a new animation cycle.
+    if (!m_isAnimating) {
+        lastActiveWindowChangedTime = system_clock::now();
+        lastAnimationDuration       = Config::animationDuration();
+        m_isAnimating = lastAnimationDuration > 0;
+
+        // If animation is disabled, set configs to their final values.
+        if (!m_isAnimating) {
+            activeAnimation   = WindowConfig::activeWindowConfig();
+            inactiveAnimation = WindowConfig::inactiveWindowConfig();
+        }
+    }
+}

--- a/src/Animation.h
+++ b/src/Animation.h
@@ -1,0 +1,105 @@
+//
+// Created by matin on 8/3/25.
+//
+
+#pragma once
+
+#include <QObject>
+#include <chrono>
+#include "WindowConfig.h"
+
+namespace KWin
+{
+    class EffectWindow;
+}
+
+namespace ShapeCorners
+{
+    class Window;
+
+    /**
+     * @brief Manages animation state and configuration for window corner effects.
+     *
+     * Handles the transition between active and inactive window configurations,
+     * updating animation progress and responding to window activation changes.
+     */
+    class Animation final : public QObject
+    {
+        Q_OBJECT
+
+    public:
+        /**
+         * @brief Initializes the animation state and connects activation signals.
+         */
+        Animation();
+
+        /**
+         * @brief Gets the current frame configuration for a window.
+         * @param window The window to query.
+         * @return Pointer to the appropriate WindowConfig for the window's state.
+         */
+        [[nodiscard]]
+        const WindowConfig *getFrameConfig(const Window &window) const;
+
+        /**
+         * @brief Gets the current configuration for the active window.
+         * @return Pointer to the active WindowConfig.
+         */
+        [[nodiscard]]
+        const WindowConfig *getActiveConfig() const
+        {
+            return &activeAnimation;
+        }
+
+        /**
+         * @brief Gets the current configuration for inactive windows.
+         * @return Pointer to the inactive WindowConfig.
+         */
+        [[nodiscard]]
+        const WindowConfig *getInactiveConfig() const
+        {
+            return &inactiveAnimation;
+        }
+
+        /**
+         * @brief Checks if an animation is currently in progress.
+         * @return True if animating, false otherwise.
+         */
+        [[nodiscard]]
+        bool isAnimating() const
+        {
+            return m_isAnimating;
+        }
+
+        /**
+         * @brief Updates the animation state and interpolates configurations.
+         *
+         * Should be called regularly to progress the animation.
+         */
+        void update();
+
+    private Q_SLOTS:
+        /**
+         * @brief Handles changes to the active window.
+         * @param w The newly activated EffectWindow.
+         */
+        void setActiveWindowChanged(const KWin::EffectWindow *w);
+
+    private:
+        /// Duration remaining for the current animation, in milliseconds.
+        long lastAnimationDuration;
+
+        /// Whether an animation is currently running.
+        bool m_isAnimating = true;
+
+        /// Timestamp of the last active window change.
+        std::chrono::system_clock::time_point lastActiveWindowChangedTime;
+
+        /// Interpolated configuration for the active window.
+        WindowConfig activeAnimation;
+
+        /// Interpolated configuration for inactive windows.
+        WindowConfig inactiveAnimation;
+    };
+
+} // namespace ShapeCorners

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,8 @@ set(effect_SRCS
     WindowConfig.cpp
     WindowManager.h
     WindowManager.cpp
+    Animation.h
+    Animation.cpp
     plugin.cpp
 )
 
@@ -34,19 +36,18 @@ else()
     )
 endif()
 
-option(DEBUG_ANIMATION "Add debug logs for animation" OFF)
 option(DEBUG_INCLUSIONS "Add debug logs for inclusion & exclusion lists" OFF)
 option(DEBUG_MAXIMIZED "Add debug logs for maximized windows" OFF)
 
-if (DEBUG_ANIMATION OR DEBUG_INCLUSIONS OR DEBUG_MAXIMIZED)
+if (CMAKE_BUILD_TYPE EQUAL "Debug")
+    message("-- Debug: Using debug build type.")
+endif ()
+
+if (DEBUG_INCLUSIONS OR DEBUG_MAXIMIZED)
+    message("-- Debug: Switched to debug mode because of other flags.")
     set(CMAKE_BUILD_TYPE "Debug")
     target_compile_definitions(kwin4_effect_shapecorners PRIVATE QT_DEBUG)
 endif ()
-
-if (DEBUG_ANIMATION)
-    message("-- Debug: Animation debug logs are enabled.")
-    target_compile_definitions(kwin4_effect_shapecorners PRIVATE DEBUG_ANIMATION)
-endif (DEBUG_ANIMATION)
 
 if (DEBUG_INCLUSIONS)
     message("-- Debug: Inclusion & exclusion debug logs are enabled.")

--- a/src/Effect.cpp
+++ b/src/Effect.cpp
@@ -18,30 +18,30 @@
  */
 
 #include "Effect.h"
+#include <QDebug>
+#include "Animation.h"
 #include "Config.h"
 #include "Utils.h"
-#include "WindowManager.h"
 #include "Window.h"
-#ifdef QT_DEBUG
-#include <QLoggingCategory>
-#endif
+#include "WindowManager.h"
 #if QT_VERSION_MAJOR >= 6
-#include <opengl/glutils.h>
-#include <effect/effectwindow.h>
-#include <effect/effecthandler.h>
 #include <core/renderviewport.h>
+#include <effect/effecthandler.h>
+#include <effect/effectwindow.h>
+#include <opengl/glutils.h>
 #else
 #include <kwineffects.h>
 #include <kwinglutils.h>
 #endif
 
-ShapeCorners::Effect::Effect() {
+ShapeCorners::Effect::Effect()
+{
     // Read configuration and initialize the effect.
     reconfigure(ReconfigureAll);
 
     // If the shader is valid, create the window manager and connect the windowAdded signal.
-    if(m_shaderManager.IsValid()) {
-        m_windowManager = std::make_unique<WindowManager>();
+    if (m_shaderManager.IsValid()) {
+        m_windowManager = std::make_unique<WindowManager>(m_animation->getInactiveConfig());
         connect(KWin::effects, &KWin::EffectsHandler::windowAdded, this, &Effect::windowAdded);
     }
 }
@@ -51,35 +51,50 @@ ShapeCorners::Effect::~Effect() = default;
 void ShapeCorners::Effect::reconfigure(const ReconfigureFlags flags)
 {
     Q_UNUSED(flags)
-    
+
     // Reload configuration settings.
     Config::self()->read();
+
+    if (!m_animation) {
+        m_animation = std::make_unique<Animation>();
+    } else {
+        m_animation->update();
+    }
 }
 
-void ShapeCorners::Effect::prePaintWindow(KWin::EffectWindow *kwindow, KWin::WindowPrePaintData &data, std::chrono::milliseconds time)
+void ShapeCorners::Effect::prePaintScreen(KWin::ScreenPrePaintData &data, const std::chrono::milliseconds presentTime)
+{
+    OffscreenEffect::prePaintScreen(data, presentTime);
+    m_animation->update();
+}
+
+void ShapeCorners::Effect::prePaintWindow(KWin::EffectWindow *kwindow, KWin::WindowPrePaintData &data,
+                                          std::chrono::milliseconds time)
 {
     // Find the managed window structure.
-    auto* window = m_windowManager->findWindow(kwindow);
-    
+    auto *window = m_windowManager->findWindow(kwindow);
+
     // If the shader is not valid or the window is not managed or doesn't need the effect, fall back to default.
-    if (!m_shaderManager.IsValid() || window == nullptr || !window->hasEffect())
-    {
+    if (!m_shaderManager.IsValid() || window == nullptr || !window->hasEffect()) {
         OffscreenEffect::prePaintWindow(kwindow, data, time);
         return;
     }
 
     // Animate window properties for smooth transitions.
-    window->animateProperties(time);
+    window->currentConfig = m_animation->getFrameConfig(*window);
+    if (m_animation->isAnimating()) {
+        kwindow->addRepaintFull();
+    }
 
     // If the window should have rounded corners, adjust the paint and opaque regions.
-    if(window->hasRoundCorners()) {
+    if (window->hasRoundCorners()) {
 #if QT_VERSION_MAJOR >= 6
         // Calculate geometry and corner size for Qt6.
-        const auto geo = kwindow->frameGeometry() * kwindow->screen()->scale();
-        const auto size = window->currentConfig.cornerRadius * kwindow->screen()->scale();
+        const auto geo  = kwindow->frameGeometry() * kwindow->screen()->scale();
+        const auto size = window->currentConfig->cornerRadius * kwindow->screen()->scale();
 #else
         // Calculate geometry and corner size for Qt5.
-        const auto geo = kwindow->frameGeometry() * KWin::effects->renderTargetScale();
+        const auto geo  = kwindow->frameGeometry() * KWin::effects->renderTargetScale();
         const auto size = window->currentConfig.cornerRadius * KWin::effects->renderTargetScale();
 #endif
 
@@ -89,11 +104,11 @@ void ShapeCorners::Effect::prePaintWindow(KWin::EffectWindow *kwindow, KWin::Win
         reg += QRect(geo.x() + geo.width() - size, geo.y(), size, size);
         reg += QRect(geo.x(), geo.y() + geo.height() - size, size, size);
         reg += QRect(geo.x() + geo.width() - size, geo.y() + geo.height() - size, size, size);
-        
+
         // Remove the rounded corners from the opaque region and add them to the paint region.
         data.opaque -= reg;
         data.paint += reg;
-        
+
         // Mark the window as having translucent regions.
         data.setTranslucent();
     }
@@ -111,15 +126,18 @@ bool ShapeCorners::Effect::supported()
 #if QT_VERSION_MAJOR >= 6
 void ShapeCorners::Effect::drawWindow(const KWin::RenderTarget &renderTarget, const KWin::RenderViewport &viewport,
                                       KWin::EffectWindow *kwindow, int mask, const QRegion &region,
-                                      KWin::WindowPaintData &data) {
+                                      KWin::WindowPaintData &data)
+{
 #else
 void ShapeCorners::Effect::drawWindow(KWin::EffectWindow *kwindow, int mask, const QRegion &region,
-                                      KWin::WindowPaintData &data) {
+                                      KWin::WindowPaintData &data)
+{
 #endif
     // Find the managed window structure.
-    auto* window = m_windowManager->findWindow(kwindow);
-    
-    // If the shader is not valid or the window is not managed or doesn't need the effect, unredirect and use default drawing.
+    const auto *window = m_windowManager->findWindow(kwindow);
+
+    // If the shader is not valid or the window is not managed or doesn't need the effect, unredirect and use default
+    // drawing.
     if (!m_shaderManager.IsValid() || window == nullptr || !window->hasEffect()) {
         unredirect(kwindow);
 #if QT_VERSION_MAJOR >= 6
@@ -157,9 +175,10 @@ void ShapeCorners::Effect::drawWindow(KWin::EffectWindow *kwindow, int mask, con
     m_shaderManager.Unbind();
 }
 
-void ShapeCorners::Effect::windowAdded(KWin::EffectWindow *kwindow) {
+void ShapeCorners::Effect::windowAdded(KWin::EffectWindow *kwindow)
+{
     // Add the new window to the manager.
-    if (m_windowManager->addWindow(kwindow)) {
+    if (m_windowManager->addWindow(kwindow, m_animation->getInactiveConfig())) {
         // Redirect the window and set the shader if it was successfully added.
         redirect(kwindow);
         setShader(kwindow, m_shaderManager.GetShader().get());

--- a/src/Effect.cpp
+++ b/src/Effect.cpp
@@ -95,7 +95,7 @@ void ShapeCorners::Effect::prePaintWindow(KWin::EffectWindow *kwindow, KWin::Win
 #else
         // Calculate geometry and corner size for Qt5.
         const auto geo  = kwindow->frameGeometry() * KWin::effects->renderTargetScale();
-        const auto size = window->currentConfig.cornerRadius * KWin::effects->renderTargetScale();
+        const auto size = window->currentConfig->cornerRadius * KWin::effects->renderTargetScale();
 #endif
 
         // Create a region for each rounded corner.

--- a/src/Effect.h
+++ b/src/Effect.h
@@ -19,15 +19,17 @@
 
 #pragma once
 
-#include "Shader.h"
 #include <QObject>
+#include "Shader.h"
 #if QT_VERSION_MAJOR >= 6
 #include <effect/offscreeneffect.h>
 #else
 #include <kwinoffscreeneffect.h>
 #endif
 
-namespace ShapeCorners {
+namespace ShapeCorners
+{
+    class Animation;
     class WindowManager;
 
     /**
@@ -38,8 +40,9 @@ namespace ShapeCorners {
      * to windows using a custom shader. It manages window addition, configuration,
      * and painting logic.
      */
-    class Effect final : public KWin::OffscreenEffect {
-    Q_OBJECT
+    class Effect final : public KWin::OffscreenEffect
+    {
+        Q_OBJECT
 
     public:
         /**
@@ -63,14 +66,22 @@ namespace ShapeCorners {
          * @param flags The reconfiguration flags.
          */
         void reconfigure(ReconfigureFlags flags) override;
-        
+
+        /**
+         * @brief Prepares the screen for painting.
+         * @param data The screen pre-paint data.
+         * @param presentTime The time at which the frame will be presented.
+         */
+        void prePaintScreen(KWin::ScreenPrePaintData &data, std::chrono::milliseconds presentTime) override;
+
         /**
          * @brief Prepares a window for painting.
          * @param w The effect window.
          * @param data The window pre-paint data.
          * @param time The time since the last frame.
          */
-        void prePaintWindow(KWin::EffectWindow *w, KWin::WindowPrePaintData &data, std::chrono::milliseconds time) override;
+        void prePaintWindow(KWin::EffectWindow *w, KWin::WindowPrePaintData &data,
+                            std::chrono::milliseconds time) override;
 
 #if QT_VERSION_MAJOR >= 6
         /**
@@ -99,30 +110,42 @@ namespace ShapeCorners {
          * @brief Returns the requested position in the effect chain.
          * @return The effect chain position.
          */
-        [[nodiscard]] 
-        int requestedEffectChainPosition() const override { return 99; }
-        
+        [[nodiscard]]
+        int requestedEffectChainPosition() const override
+        {
+            return 99;
+        }
+
         /**
          * @brief Indicates whether the effect blocks direct scanout.
          * @return False, this effect does not block direct scanout.
          */
         [[nodiscard]]
-        bool blocksDirectScanout() const override { return false; }
-        
+        bool blocksDirectScanout() const override
+        {
+            return false;
+        }
+
         /**
          * @brief Checks if the effect is currently active.
          * @return True if the shader manager is valid, false otherwise.
          */
         [[nodiscard]]
-        bool isActive() const override { return m_shaderManager.IsValid(); }
-        
+        bool isActive() const override
+        {
+            return m_shaderManager.IsValid();
+        }
+
         /**
          * @brief Indicates which features this effect provides.
          * @param feature The feature to check.
          * @return True if the feature is provided, false otherwise.
          */
-        [[nodiscard]] 
-        bool provides(const Feature feature) override { return feature == Nothing; }
+        [[nodiscard]]
+        bool provides(const Feature feature) override
+        {
+            return feature == Nothing;
+        }
 
     private Q_SLOTS:
         /**
@@ -136,5 +159,7 @@ namespace ShapeCorners {
         Shader m_shaderManager;
         /// Manages the windows affected by the effect.
         std::unique_ptr<WindowManager> m_windowManager;
+        /// Manages the animation state for window corner effects.
+        std::unique_ptr<Animation> m_animation;
     };
-}
+} // namespace ShapeCorners

--- a/src/FloatColor.h
+++ b/src/FloatColor.h
@@ -17,7 +17,8 @@
 #include <sstream>
 #endif
 
-namespace ShapeCorners {
+namespace ShapeCorners
+{
     /**
      * @brief Represents a color with floating-point RGBA channels.
      *
@@ -30,21 +31,24 @@ namespace ShapeCorners {
         float g;
         float b;
         float a;
+
         constexpr static float MIN_CHANNEL_VALUE = 0.0F;
         constexpr static float MAX_CHANNEL_VALUE = 255.0F;
 
         /**
          * @brief Default constructor. Initializes all channels to MIN_CHANNEL_VALUE.
          */
-        constexpr FloatColor() :
-                FloatColor(MIN_CHANNEL_VALUE, MIN_CHANNEL_VALUE, MIN_CHANNEL_VALUE, MIN_CHANNEL_VALUE) {}
+        constexpr FloatColor() : FloatColor(MIN_CHANNEL_VALUE, MIN_CHANNEL_VALUE, MIN_CHANNEL_VALUE, MIN_CHANNEL_VALUE)
+        {
+        }
 
         /**
          * @brief Constructs a FloatColor from a QColor.
          * @param color The QColor to convert.
          */
-        explicit FloatColor(const QColor &color) :
-                FloatColor(color.red(), color.green(), color.blue(), color.alpha()) {}
+        explicit FloatColor(const QColor &color) : FloatColor(color.red(), color.green(), color.blue(), color.alpha())
+        {
+        }
 
         /**
          * @brief Constructs a FloatColor from integer RGBA values.
@@ -54,10 +58,10 @@ namespace ShapeCorners {
          * @param alpha Alpha channel [0, 255], defaults to MAX_CHANNEL_VALUE.
          */
         constexpr FloatColor(const int red, const int green, const int blue, const int alpha = MAX_CHANNEL_VALUE) :
-                r(static_cast<float>(red)),
-                g(static_cast<float>(green)),
-                b(static_cast<float>(blue)),
-                a(static_cast<float>(alpha)) {}
+            r(static_cast<float>(red)), g(static_cast<float>(green)), b(static_cast<float>(blue)),
+            a(static_cast<float>(alpha))
+        {
+        }
 
         /**
          * @brief Constructs a FloatColor from float RGBA values.
@@ -67,21 +71,18 @@ namespace ShapeCorners {
          * @param alpha Alpha channel, defaults to MAX_CHANNEL_VALUE.
          */
         constexpr FloatColor(const float red, const float green, const float blue,
-                             const float alpha = MAX_CHANNEL_VALUE) :
-                r(red), g(green), b(blue), a(alpha) {}
+                             const float alpha = MAX_CHANNEL_VALUE) : r(red), g(green), b(blue), a(alpha)
+        {
+        }
 
         /**
          * @brief Subtracts another FloatColor from this one.
          * @param other The color to subtract.
          * @return The result of the subtraction.
          */
-        constexpr FloatColor operator-(const FloatColor &other) const noexcept {
-            return {
-                r - other.r,
-                g - other.g,
-                b - other.b,
-                a - other.a
-            };
+        constexpr FloatColor operator-(const FloatColor &other) const
+        {
+            return {r - other.r, g - other.g, b - other.b, a - other.a};
         }
 
         /**
@@ -89,13 +90,9 @@ namespace ShapeCorners {
          * @param other The color to add.
          * @return The result of the addition.
          */
-        constexpr FloatColor operator+(const FloatColor &other) const noexcept {
-            return {
-                r + other.r,
-                g + other.g,
-                b + other.b,
-                a + other.a
-            };
+        constexpr FloatColor operator+(const FloatColor &other) const
+        {
+            return {r + other.r, g + other.g, b + other.b, a + other.a};
         }
 
         /**
@@ -105,13 +102,9 @@ namespace ShapeCorners {
          * @return The result of the multiplication.
          */
         template<typename T>
-        constexpr FloatColor operator*(const T &scalar) const noexcept {
-            return {
-                r * scalar,
-                g * scalar,
-                b * scalar,
-                a * scalar
-            };
+        constexpr FloatColor operator*(const T &scalar) const
+        {
+            return {r * scalar, g * scalar, b * scalar, a * scalar};
         }
 
         /**
@@ -121,13 +114,9 @@ namespace ShapeCorners {
          * @return The result of the division.
          */
         template<typename T>
-        constexpr FloatColor operator/(const T &scalar) const noexcept {
-            return {
-                r / scalar,
-                g / scalar,
-                b / scalar,
-                a / scalar
-            };
+        constexpr FloatColor operator/(const T &scalar) const
+        {
+            return {r / scalar, g / scalar, b / scalar, a / scalar};
         }
 
         /**
@@ -135,7 +124,8 @@ namespace ShapeCorners {
          * @return True if all channels are zero, false otherwise.
          */
         [[nodiscard]]
-        constexpr bool operator!() const noexcept {
+        constexpr bool operator!() const
+        {
             return (r <= 0 && g <= 0 && b <= 0 && a <= 0);
         }
 
@@ -144,13 +134,9 @@ namespace ShapeCorners {
          * @return The QColor representation.
          */
         [[nodiscard]]
-        QColor toQColor() const noexcept {
-            return {
-                static_cast<int>(r),
-                static_cast<int>(g),
-                static_cast<int>(b),
-                static_cast<int>(a)
-            };
+        QColor toQColor() const
+        {
+            return {static_cast<int>(r), static_cast<int>(g), static_cast<int>(b), static_cast<int>(a)};
         }
 
 #ifdef QT_DEBUG
@@ -159,7 +145,8 @@ namespace ShapeCorners {
          * @return The string representation.
          */
         [[nodiscard]]
-        std::string toString() const noexcept {
+        std::string toString() const
+        {
             std::stringstream stream;
             stream << "[ " << r << " , " << g << " , " << b << " , " << a << " ]";
             return stream.str();
@@ -170,7 +157,8 @@ namespace ShapeCorners {
          * @brief Adds another FloatColor to this one in-place.
          * @param other The color to add.
          */
-        constexpr void operator+=(const FloatColor &other) noexcept {
+        constexpr void operator+=(const FloatColor &other)
+        {
             r += other.r;
             g += other.g;
             b += other.b;
@@ -180,7 +168,8 @@ namespace ShapeCorners {
         /**
          * @brief Rounds all channels to the nearest integer.
          */
-        constexpr void round() noexcept {
+        constexpr void round()
+        {
             r = std::round(r);
             g = std::round(g);
             b = std::round(b);
@@ -190,7 +179,8 @@ namespace ShapeCorners {
         /**
          * @brief Clamps all channels to the valid range [MIN_CHANNEL_VALUE, MAX_CHANNEL_VALUE].
          */
-        constexpr void clamp() noexcept {
+        constexpr void clamp()
+        {
             r = std::clamp(r, MIN_CHANNEL_VALUE, MAX_CHANNEL_VALUE);
             g = std::clamp(g, MIN_CHANNEL_VALUE, MAX_CHANNEL_VALUE);
             b = std::clamp(b, MIN_CHANNEL_VALUE, MAX_CHANNEL_VALUE);
@@ -201,32 +191,24 @@ namespace ShapeCorners {
          * @brief Sets the alpha channel.
          * @param alpha The new alpha value.
          */
-        constexpr void setAlpha(const int alpha) noexcept {
-            a = static_cast<float>(alpha);
-        }
+        constexpr void setAlpha(const int alpha) { a = static_cast<float>(alpha); }
 
         /**
          * @brief Sets the red channel.
          * @param red The new red value.
          */
-        constexpr void setRed(const int red) noexcept {
-            r = static_cast<float>(red);
-        }
+        constexpr void setRed(const int red) { r = static_cast<float>(red); }
 
         /**
          * @brief Sets the green channel.
          * @param green The new green value.
          */
-        constexpr void setGreen(const int green) noexcept {
-            g = static_cast<float>(green);
-        }
+        constexpr void setGreen(const int green) { g = static_cast<float>(green); }
 
         /**
          * @brief Sets the blue channel.
          * @param blue The new blue value.
          */
-        constexpr void setBlue(const int blue) noexcept {
-            b = static_cast<float>(blue);
-        }
+        constexpr void setBlue(const int blue) { b = static_cast<float>(blue); }
     };
-}
+} // namespace ShapeCorners

--- a/src/Shader.cpp
+++ b/src/Shader.cpp
@@ -1,10 +1,11 @@
 
 #include "Shader.h"
-#include "Window.h"
-#include "Config.h"
-#include "Utils.h"
 #include <QFile>
 #include <QStandardPaths>
+#include "Config.h"
+#include "Utils.h"
+#include "Window.h"
+#include "WindowConfig.h"
 #if QT_VERSION_MAJOR >= 6
 #include <effect/effectwindow.h>
 #include <opengl/glutils.h>
@@ -13,19 +14,18 @@
 #include <kwinglutils.h>
 #endif
 
-namespace ShapeCorners {
+namespace ShapeCorners
+{
     /**
      * @brief Converts a QSizeF to a QVector2D.
      * @param size The QSizeF to convert.
      * @return The corresponding QVector2D.
      */
-    constexpr QVector2D toVector2D(const QSizeF &size) noexcept {
-        return {
-            static_cast<float>(size.width()),
-            static_cast<float>(size.height())
-        };
+    constexpr QVector2D toVector2D(const QSizeF &size)
+    {
+        return {static_cast<float>(size.width()), static_cast<float>(size.height())};
     }
-}
+} // namespace ShapeCorners
 
 ShapeCorners::Shader::Shader() {
 
@@ -42,39 +42,37 @@ ShapeCorners::Shader::Shader() {
     }
 
     // Assign uniform variable locations
-    m_shader_windowSize = m_shader->uniformLocation("windowSize");
-    m_shader_windowExpandedSize = m_shader->uniformLocation("windowExpandedSize");
-    m_shader_windowTopLeft = m_shader->uniformLocation("windowTopLeft");
-    m_shader_usesNativeShadows = m_shader->uniformLocation("usesNativeShadows");
-    m_shader_shadowColor = m_shader->uniformLocation("shadowColor");
-    m_shader_shadowSize = m_shader->uniformLocation("shadowSize");
-    m_shader_radius = m_shader->uniformLocation("radius");
-    m_shader_outlineColor = m_shader->uniformLocation("outlineColor");
-    m_shader_outlineThickness = m_shader->uniformLocation("outlineThickness");
-    m_shader_secondOutlineColor = m_shader->uniformLocation("secondOutlineColor");
+    m_shader_windowSize             = m_shader->uniformLocation("windowSize");
+    m_shader_windowExpandedSize     = m_shader->uniformLocation("windowExpandedSize");
+    m_shader_windowTopLeft          = m_shader->uniformLocation("windowTopLeft");
+    m_shader_usesNativeShadows      = m_shader->uniformLocation("usesNativeShadows");
+    m_shader_shadowColor            = m_shader->uniformLocation("shadowColor");
+    m_shader_shadowSize             = m_shader->uniformLocation("shadowSize");
+    m_shader_radius                 = m_shader->uniformLocation("radius");
+    m_shader_outlineColor           = m_shader->uniformLocation("outlineColor");
+    m_shader_outlineThickness       = m_shader->uniformLocation("outlineThickness");
+    m_shader_secondOutlineColor     = m_shader->uniformLocation("secondOutlineColor");
     m_shader_secondOutlineThickness = m_shader->uniformLocation("secondOutlineThickness");
-    m_shader_front = m_shader->uniformLocation("front");
+    m_shader_front                  = m_shader->uniformLocation("front");
     qInfo() << "ShapeCorners: shaders loaded.";
 }
 
-bool ShapeCorners::Shader::IsValid() const noexcept {
-    return m_shader && m_shader->isValid();
-}
+bool ShapeCorners::Shader::IsValid() const { return m_shader && m_shader->isValid(); }
 
-void ShapeCorners::Shader::Bind(const Window &window, const double scale) const noexcept {
+void ShapeCorners::Shader::Bind(const Window &window, const double scale) const
+{
     if (!IsValid()) {
         return;
     }
 
     // Calculate scaled geometries
-    const auto frameGeometry = window.w->frameGeometry() * scale;
+    const auto frameGeometry    = window.w->frameGeometry() * scale;
     const auto expandedGeometry = window.w->expandedGeometry() * scale;
     // Calculate the offset between expanded and frame geometry
     const auto frameOffset = QVector2D(frameGeometry.topLeft() - expandedGeometry.topLeft());
     // Clamp the shadow size to the maximum allowed
     const qreal max_shadow_size = frameOffset.length();
-    const auto shadowSize = std::min(window.currentConfig.shadowSize * scale, max_shadow_size);
-
+    const auto  shadowSize      = std::min(window.currentConfig->shadowSize * scale, max_shadow_size);
     // Push the shader to the rendering stack
     KWin::ShaderManager::instance()->pushShader(m_shader.get());
     // Set all required uniforms
@@ -83,16 +81,23 @@ void ShapeCorners::Shader::Bind(const Window &window, const double scale) const 
     m_shader->setUniform(m_shader_windowTopLeft, frameOffset);
     m_shader->setUniform(m_shader_usesNativeShadows, static_cast<int>(Config::useNativeDecorationShadows()));
     m_shader->setUniform(m_shader_front, 0);
-    m_shader->setUniform(m_shader_radius, static_cast<float>(window.currentConfig.cornerRadius * scale));
-    m_shader->setUniform(m_shader_outlineThickness, static_cast<float>(window.currentConfig.outlineSize * scale));
-    m_shader->setUniform(m_shader_secondOutlineThickness, static_cast<float>(window.currentConfig.secondOutlineSize * scale));
+    m_shader->setUniform(m_shader_radius, static_cast<float>(window.currentConfig->cornerRadius * scale));
+    m_shader->setUniform(m_shader_outlineThickness, static_cast<float>(window.currentConfig->outlineSize * scale));
+    m_shader->setUniform(m_shader_secondOutlineThickness,
+                         static_cast<float>(window.currentConfig->secondOutlineSize * scale));
     m_shader->setUniform(m_shader_shadowSize, static_cast<float>(shadowSize));
-    m_shader->setUniform(m_shader_outlineColor, window.currentConfig.outlineColor.toQColor());
-    m_shader->setUniform(m_shader_secondOutlineColor, window.currentConfig.secondOutlineColor.toQColor());
-    m_shader->setUniform(m_shader_shadowColor, window.currentConfig.shadowColor.toQColor());
+    m_shader->setUniform(m_shader_shadowColor, window.currentConfig->shadowColor.toQColor());
+    if (window.hasOutline()) {
+        m_shader->setUniform(m_shader_outlineColor, window.currentConfig->outlineColor.toQColor());
+        m_shader->setUniform(m_shader_secondOutlineColor, window.currentConfig->secondOutlineColor.toQColor());
+    } else {
+        m_shader->setUniform(m_shader_outlineColor, 0);
+        m_shader->setUniform(m_shader_secondOutlineColor, 0);
+    }
 }
 
-void ShapeCorners::Shader::Unbind() const noexcept {
+void ShapeCorners::Shader::Unbind() const
+{
     if (!IsValid()) {
         return;
     }

--- a/src/Shader.h
+++ b/src/Shader.h
@@ -9,11 +9,13 @@
 
 #include <memory>
 
-namespace KWin {
+namespace KWin
+{
     class GLShader;
 }
 
-namespace ShapeCorners {
+namespace ShapeCorners
+{
     class Window;
 
     /**
@@ -23,7 +25,8 @@ namespace ShapeCorners {
      * Loads the correct shader based on the GL platform in KWin, assigns uniform variable locations,
      * and provides methods to bind and unbind the shader during rendering.
      */
-    class Shader {
+    class Shader
+    {
     public:
         /**
          * \brief Loads the correct shader based on the GL platform in KWin.
@@ -36,7 +39,7 @@ namespace ShapeCorners {
          * \return True if the shader is valid and loaded
          */
         [[nodiscard]]
-        bool IsValid() const noexcept;
+        bool IsValid() const;
 
         /**
          * \brief This function assigns the required variables to the shader.
@@ -45,19 +48,19 @@ namespace ShapeCorners {
          * \param window The window that the effect will be rendering on
          * \param scale The scale of the screen
          */
-        void Bind(const Window &window, double scale) const noexcept;
+        void Bind(const Window &window, double scale) const;
 
         /**
          * \brief Pop the shader from the stack of rendering.
          * \note  This needs to be called after each window is rendered.
          */
-        void Unbind() const noexcept;
+        void Unbind() const;
 
         /**
          * @brief Gets a reference to the unique pointer of the loaded shader.
          * \return Reference to the unique pointer of the loaded shader.
          */
-        std::unique_ptr<KWin::GLShader> &GetShader() noexcept { return m_shader; }
+        std::unique_ptr<KWin::GLShader> &GetShader() { return m_shader; }
 
     private:
         /**
@@ -80,7 +83,8 @@ namespace ShapeCorners {
 
         /**
          * \brief Reference to `uniform vec2 windowTopLeft;`
-         *        Containing the distance between the top-left of `expandedGeometry` and the top-left of `frameGeometry`.
+         *        Containing the distance between the top-left of `expandedGeometry` and the top-left of
+         * `frameGeometry`.
          * \note  When `windowTopLeft = {0,0}`, it means `expandedGeometry = frameGeometry` and there is no shadow.
          */
         int m_shader_windowTopLeft = 0;
@@ -135,8 +139,9 @@ namespace ShapeCorners {
 
         /**
          * \brief Reference to `uniform sampler2D front;`
-         *        Containing the active texture. When assigned to zero, it will contain the painted contents of the window.
+         *        Containing the active texture. When assigned to zero, it will contain the painted contents of the
+         * window.
          */
         int m_shader_front = 0;
     };
-}
+} // namespace ShapeCorners

--- a/src/TileChecker.cpp
+++ b/src/TileChecker.cpp
@@ -1,7 +1,7 @@
 
 #include "TileChecker.h"
-#include "Window.h"
 #include <ranges>
+#include "Window.h"
 #if QT_VERSION_MAJOR >= 6
 #include <effect/effecthandler.h>
 #include <utility>
@@ -20,9 +20,10 @@ constexpr static uint8_t MAX_TILE_DEPTH = 5;
 constexpr static uint8_t MAX_GAP_SIZE = 40;
 
 template<bool vertical>
-bool ShapeCorners::TileChecker::checkTiled_Recursive(double window_start, const uint8_t depth) noexcept {
+bool ShapeCorners::TileChecker::checkTiled_Recursive(double window_start, const uint8_t depth)
+{
     if (window_start == screen_end) {
-        return true;    // Found the last chain of tiles
+        return true; // Found the last chain of tiles
     }
     if (window_start > screen_end) {
         return false;
@@ -32,7 +33,7 @@ bool ShapeCorners::TileChecker::checkTiled_Recursive(double window_start, const 
     }
 
     bool found_last_chain = false;
-    for (auto& [kwindow, window]: m_managed) {
+    for (auto &[kwindow, window]: m_managed) {
 
         // Skip windows without an effect
         if (!window->hasEffect()) {
@@ -40,12 +41,12 @@ bool ShapeCorners::TileChecker::checkTiled_Recursive(double window_start, const 
         }
 
         // Select x/y and width/height based on orientation
-        const auto orientation_x = std::get<vertical>(std::make_pair(kwindow->x(), kwindow->y()));
+        const auto orientation_x     = std::get<vertical>(std::make_pair(kwindow->x(), kwindow->y()));
         const auto orientation_width = std::get<vertical>(std::make_pair(kwindow->width(), kwindow->height()));
 
         if (depth == 0) {
             // Ignore windows with a gap larger than allowed
-            if(orientation_x - window_start > MAX_GAP_SIZE) {
+            if (orientation_x - window_start > MAX_GAP_SIZE) {
                 continue;
             }
             gap = orientation_x - window_start;
@@ -55,28 +56,30 @@ bool ShapeCorners::TileChecker::checkTiled_Recursive(double window_start, const 
         // If the window starts at the expected position and has a positive size
         if (orientation_x == window_start && orientation_width > 0) {
             // Recursively check the next tile in the chain
-            if (checkTiled_Recursive<vertical>(window_start + orientation_width + gap, depth+1)) {
-                window->isTiled = true;   // Mark every tile as you go back to the first.
+            if (checkTiled_Recursive<vertical>(window_start + orientation_width + gap, depth + 1)) {
+                window->isTiled  = true; // Mark every tile as you go back to the first.
                 found_last_chain = true;
             }
         }
 
         // Revert changes to window_start for the next iteration
-        if(depth == 0) {
+        if (depth == 0) {
             window_start -= gap;
         }
     }
     return found_last_chain;
 }
 
-void ShapeCorners::TileChecker::clearTiles() const noexcept {
+void ShapeCorners::TileChecker::clearTiles() const
+{
     // Iterate over all managed windows and reset their isTiled flag
-    for (const auto & window: m_managed | std::views::values) {
+    for (const auto &window: m_managed | std::views::values) {
         window->isTiled = false;
     }
 }
 
-void ShapeCorners::TileChecker::checkTiles(const QRect& screen) noexcept {
+void ShapeCorners::TileChecker::checkTiles(const QRect &screen)
+{
     // Check horizontally
     screen_end = screen.x() + screen.width();
     checkTiled_Recursive<false>(screen.x(), 0);

--- a/src/TileChecker.h
+++ b/src/TileChecker.h
@@ -12,11 +12,13 @@
 #include <cstdint>
 
 class QRect;
-namespace KWin {
+namespace KWin
+{
     class EffectWindow;
 }
 
-namespace ShapeCorners {
+namespace ShapeCorners
+{
     class Window;
 
     /**
@@ -26,31 +28,32 @@ namespace ShapeCorners {
      * Recursively checks window arrangements to determine if windows are tiled,
      * and marks them accordingly. Supports both horizontal and vertical tiling checks.
      */
-    class TileChecker {
+    class TileChecker
+    {
 
     public:
         /**
          * @brief Constructs a TileChecker with a reference to the managed window list.
          * @param windowList Reference to the managed window list.
          */
-        explicit TileChecker(WindowList& windowList): m_managed(windowList) {}
+        explicit TileChecker(WindowList &windowList) : m_managed(windowList) {}
 
         /**
          * @brief Clears the tiled state for all managed windows.
          */
-        void clearTiles() const noexcept;
+        void clearTiles() const;
 
         /**
          * @brief Checks and marks tiled windows based on the given screen geometry.
          * @param screen The QRect representing the screen area to check.
          */
-        void checkTiles(const QRect& screen) noexcept;
+        void checkTiles(const QRect &screen);
 
     private:
         /**
          * @brief Reference to the managed window list.
          */
-        WindowList& m_managed;
+        WindowList &m_managed;
 
         /**
          * @brief End coordinate of the screen (x or y, depending on orientation).
@@ -70,6 +73,6 @@ namespace ShapeCorners {
          * @return True if a valid chain of tiles is found, false otherwise.
          */
         template<bool vertical>
-        bool checkTiled_Recursive(double window_start, uint8_t depth) noexcept;
+        bool checkTiled_Recursive(double window_start, uint8_t depth);
     };
-}
+} // namespace ShapeCorners

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -9,7 +9,8 @@
 
 #include <QRectF>
 
-namespace ShapeCorners {
+namespace ShapeCorners
+{
 
     /**
      * @brief Scales a QRect by a floating-point scale factor.
@@ -17,13 +18,9 @@ namespace ShapeCorners {
      * @param scale The scale factor.
      * @return The scaled QRectF.
      */
-    constexpr QRectF operator*(const QRect &rect, const qreal scale) noexcept {
-        return {
-            rect.x() * scale,
-            rect.y() * scale,
-            rect.width() * scale,
-            rect.height() * scale
-        };
+    constexpr QRectF operator*(const QRect &rect, const qreal scale)
+    {
+        return {rect.x() * scale, rect.y() * scale, rect.width() * scale, rect.height() * scale};
     }
 
     /**
@@ -32,12 +29,8 @@ namespace ShapeCorners {
      * @param scale The scale factor.
      * @return The scaled QRectF.
      */
-    constexpr QRectF operator*(const QRectF &rect, const qreal scale) noexcept {
-        return {
-            rect.x() * scale,
-            rect.y() * scale,
-            rect.width() * scale,
-            rect.height() * scale
-        };
+    constexpr QRectF operator*(const QRectF &rect, const qreal scale)
+    {
+        return {rect.x() * scale, rect.y() * scale, rect.width() * scale, rect.height() * scale};
     }
-}
+} // namespace ShapeCorners

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -1,39 +1,34 @@
 
 #include "Window.h"
+#include <WindowConfig.h>
 #include "Config.h"
+
 #if QT_VERSION_MAJOR >= 6
 #include <effect/effecthandler.h>
 #else
 #include <kwineffects.h>
 #endif
 
-ShapeCorners::Window::Window(KWin::EffectWindow* kwindow)
-    : w(kwindow)
-    , currentConfig(getExpectedConfig())
+ShapeCorners::Window::Window(KWin::EffectWindow *kwindow, const WindowConfig *config) :
+    w(kwindow), currentConfig(config)
 {
     connect(Config::self(), &Config::configChanged, this, &Window::configChanged);
     configChanged();
 }
 
-bool ShapeCorners::Window::isActive() const noexcept {
-    return KWin::effects->activeWindow() == w;
+bool ShapeCorners::Window::isActive() const { return KWin::effects->activeWindow() == w; }
+
+bool ShapeCorners::Window::hasEffect() const
+{
+    return (w->expandedGeometry().isValid() &&
+            ((w->isNormalWindow() && Config::includeNormalWindows()) || (w->isDialog() && Config::includeDialogs()) ||
+             isIncluded) &&
+            !isExcluded && (hasRoundCorners() || hasOutline()));
 }
 
-bool ShapeCorners::Window::hasEffect() const noexcept {
-    return (
-        w->expandedGeometry().isValid()
-        && (
-                (w->isNormalWindow() && Config::includeNormalWindows())
-                || (w->isDialog() && Config::includeDialogs())
-                || isIncluded
-        )
-        && !isExcluded
-        && (hasRoundCorners() || hasOutline())
-    );
-}
-
-bool ShapeCorners::Window::hasRoundCorners() const noexcept {
-    if (currentConfig.cornerRadius <= 0) {
+bool ShapeCorners::Window::hasRoundCorners() const
+{
+    if (currentConfig->cornerRadius <= 0) {
         return false;
     }
     if (w->isFullScreen()) {
@@ -48,7 +43,8 @@ bool ShapeCorners::Window::hasRoundCorners() const noexcept {
     return true;
 }
 
-bool ShapeCorners::Window::hasOutline() const noexcept {
+bool ShapeCorners::Window::hasOutline() const
+{
     if (w->isFullScreen()) {
         return !Config::disableOutlineFullScreen();
     }
@@ -61,80 +57,20 @@ bool ShapeCorners::Window::hasOutline() const noexcept {
     return true;
 }
 
-ShapeCorners::WindowConfig ShapeCorners::Window::getExpectedConfig() const noexcept {
-
-    // Choose active or inactive config values based on window state
-    WindowConfig config = isActive() ?
-        WindowConfig::activeWindowConfig():
-        WindowConfig::inactiveWindowConfig();
-    if (!hasOutline()) {
-        config.outlineColor.setAlpha(0);
-        config.secondOutlineColor.setAlpha(0);
-    }
-    return config;
-}
-
-void ShapeCorners::Window::animateProperties(const std::chrono::milliseconds& time) noexcept {
-
-    // If the properties are not initialized yet, don't animate them.
-    if (!Config::animationEnabled()) {
-        currentConfig = getExpectedConfig();
-        return;
-    }
-
-    // Calculate the time delta since the last animation step
-    const auto deltaTime = static_cast<float>((time - m_last_time).count());
-    m_last_time = time;
-    if (deltaTime <= 0) {
-        return;
-    }
-
-    // Find the destination config
-    const auto destinationConfig = getExpectedConfig();
-
-    // Calculate the animation step
-    auto deltaConfig = (destinationConfig - currentConfig) / deltaTime;
-
-    // Adjust decimal precision for smoother animation
-    deltaConfig.round();
-
-    // If all deltas are zero, the animation is finished
-    if (!deltaConfig) {
-#ifdef DEBUG_ANIMATION
-        if (repaintCount > 0) {
-            qDebug() << "ShapeCorners: repainted" << w.windowClass() << repaintCount << "times for animation.";
-        }
-        repaintCount = 0;
-#endif
-        return;
-    }
-
-    // Adjust properties by their deltas
-    currentConfig += deltaConfig;
-
-    // Clamp properties to their target values and valid ranges
-    currentConfig.clamp(deltaConfig, destinationConfig);
-
-    // The animation is still in progress
-#ifdef DEBUG_ANIMATION
-    repaintCount++;
-#endif
-    w->addRepaintFull();
-}
-
 #ifdef QT_DEBUG
-QDebug KWin::operator<<(const QDebug & debug, EffectWindow& kwindow) {
+QDebug KWin::operator<<(const QDebug &debug, const EffectWindow &kwindow)
+{
     return (debug << kwindow.windowType() << kwindow.windowClass() << kwindow.caption());
 }
 #endif
 
-void ShapeCorners::Window::configChanged() {
+void ShapeCorners::Window::configChanged()
+{
     isExcluded = false;
     isIncluded = false;
-    for (auto& exclusion: Config::exclusions()) {
-        if (w->windowClass().contains(exclusion, Qt::CaseInsensitive)
-            || captionAfterDash().contains(exclusion, Qt::CaseInsensitive)
-                ) {
+    for (auto &exclusion: Config::exclusions()) {
+        if (w->windowClass().contains(exclusion, Qt::CaseInsensitive) ||
+            captionAfterDash().contains(exclusion, Qt::CaseInsensitive)) {
             isExcluded = true;
 #ifdef DEBUG_INCLUSIONS
             qDebug() << "ShapeCorners: Excluded window:" << *this;
@@ -142,10 +78,9 @@ void ShapeCorners::Window::configChanged() {
             return;
         }
     }
-    for (auto& inclusion: Config::inclusions()) {
-        if (w->windowClass().contains(inclusion, Qt::CaseInsensitive)
-            || captionAfterDash().contains(inclusion, Qt::CaseInsensitive)
-        ) {
+    for (auto &inclusion: Config::inclusions()) {
+        if (w->windowClass().contains(inclusion, Qt::CaseInsensitive) ||
+            captionAfterDash().contains(inclusion, Qt::CaseInsensitive)) {
             isIncluded = true;
 #ifdef DEBUG_INCLUSIONS
             qDebug() << "ShapeCorners: Included window:" << *this;
@@ -155,15 +90,17 @@ void ShapeCorners::Window::configChanged() {
     }
 }
 
-QJsonObject ShapeCorners::Window::toJson() const noexcept {
-    auto json = QJsonObject();
-    json[QStringLiteral("class")] = w->windowClass();
+QJsonObject ShapeCorners::Window::toJson() const
+{
+    QJsonObject json;
+    json[QStringLiteral("class")]   = w->windowClass();
     json[QStringLiteral("caption")] = w->caption();
     return json;
 }
 
-QString ShapeCorners::Window::captionAfterDash() const noexcept {
-    const auto sep = QStringLiteral(" — ");
+QString ShapeCorners::Window::captionAfterDash() const
+{
+    const auto sep   = QStringLiteral(" — ");
     const auto index = w->caption().indexOf(sep);
     if (index == -1) {
         return w->caption();

--- a/src/Window.h
+++ b/src/Window.h
@@ -8,11 +8,9 @@
 
 #pragma once
 
-#include "WindowConfig.h"
 #include <QObject>
 #include <QString>
 #include <chrono>
-#include <memory>
 #ifdef QT_DEBUG
 #include <QDebug>
 #endif
@@ -27,11 +25,13 @@ namespace KWin
     /**
      * @brief Debug operator for EffectWindow.
      */
-    QDebug operator<<(const QDebug & debug, EffectWindow& kwindow);
+    QDebug operator<<(const QDebug &debug, const EffectWindow &kwindow);
 #endif
-}
+} // namespace KWin
 
-namespace ShapeCorners {
+namespace ShapeCorners
+{
+    struct WindowConfig;
 
     /**
      * @class Window
@@ -40,14 +40,15 @@ namespace ShapeCorners {
      * Stores and animates properties such as corner radius, shadow, and outline for a managed window.
      * Handles inclusion/exclusion logic and provides utility methods for window state.
      */
-    class Window final : public QObject {
+    class Window final : public QObject
+    {
         Q_OBJECT
 
     public:
         /**
          * @brief Reference to the managed KWin EffectWindow.
          */
-        KWin::EffectWindow* w;
+        KWin::EffectWindow *w;
 
         /**
          * @brief True if the window is tiled.
@@ -62,65 +63,53 @@ namespace ShapeCorners {
         /**
          * @brief Current window configuration that may be animated.
          */
-        WindowConfig currentConfig;
-
-#ifdef DEBUG_ANIMATION
-        /**
-         * @brief Counts the number of repaints for animation (debug only).
-         */
-        uint32_t repaintCount = 0;
-#endif
+        const WindowConfig *currentConfig;
 
         /**
          * @brief Constructs a Window object for the given EffectWindow.
          * @param kwindow Reference to the KWin EffectWindow.
+         * @param config Reference to the initial WindowConfig of the Window.
          */
-        explicit Window(KWin::EffectWindow* kwindow);
+        explicit Window(KWin::EffectWindow *kwindow, const WindowConfig *config);
 
         // don't allow copying
-        Window(const Window &) = delete;
+        Window(const Window &)            = delete;
         Window &operator=(const Window &) = delete;
-
-        /**
-         * @brief Animates window properties towards their target values.
-         * @param time The current time in milliseconds.
-         */
-        void animateProperties(const std::chrono::milliseconds &time) noexcept;
 
         /**
          * @brief Checks if the window is the currently active window.
          * @return True if the window is active.
          */
         [[nodiscard]]
-        bool isActive() const noexcept;
+        bool isActive() const;
 
         /**
          * @brief Checks if the window should have rounded corners.
          * @return True if the window has rounded corners.
          */
         [[nodiscard]]
-        bool hasRoundCorners() const noexcept;
+        bool hasRoundCorners() const;
 
         /**
          * @brief Checks if the window should have an outline.
          * @return True if the window has an outline.
          */
         [[nodiscard]]
-        bool hasOutline() const noexcept;
+        bool hasOutline() const;
 
         /**
          * @brief Checks if the window should have any ShapeCorners effect.
          * @return True if the window should be affected by the effect.
          */
         [[nodiscard]]
-        bool hasEffect() const noexcept;
+        bool hasEffect() const;
 
         /**
          * @brief Serializes window information to JSON.
          * @return QJsonObject containing window class and caption.
          */
         [[nodiscard]]
-        QJsonObject toJson() const noexcept;
+        QJsonObject toJson() const;
 
         /**
          *  @brief Returns the windows caption after the " — ".
@@ -131,7 +120,7 @@ namespace ShapeCorners {
          *  @return The caption after the dash, or the full caption if not found.
          */
         [[nodiscard]]
-        QString captionAfterDash() const noexcept;
+        QString captionAfterDash() const;
 
     public Q_SLOTS:
         /**
@@ -141,11 +130,6 @@ namespace ShapeCorners {
 
     private:
         /**
-         * @brief Last animation time.
-         */
-        std::chrono::milliseconds m_last_time = {};
-
-        /**
          * @brief True if the window is explicitly included by config.
          */
         bool isIncluded = false;
@@ -154,19 +138,12 @@ namespace ShapeCorners {
          * @brief True if the window is explicitly excluded by config.
          */
         bool isExcluded = false;
-
-        /**
-         * @brief Returns the expected configuration for the window based on its active or inactive state.
-         * @return The WindowConfig with the expected values for this window.
-         */
-        [[nodiscard]]
-        WindowConfig getExpectedConfig() const noexcept;
     };
 
 #ifdef QT_DEBUG
     /**
      * @brief Debug operator for ShapeCorners::Window.
      */
-    inline QDebug operator<<(const QDebug & debug, const Window& win) noexcept { return (debug << *win.w); }
+    inline QDebug operator<<(const QDebug &debug, const Window &win) { return (debug << *win.w); }
 #endif
-}
+} // namespace ShapeCorners

--- a/src/WindowConfig.cpp
+++ b/src/WindowConfig.cpp
@@ -1,8 +1,9 @@
 #include "WindowConfig.h"
-#include "Config.h"
 #include <QWidget>
+#include "Config.h"
 
-namespace ShapeCorners {
+namespace ShapeCorners
+{
     /**
      * \brief Used only for its `palette()` function which holds the currently active highlight colors.
      */
@@ -15,7 +16,8 @@ namespace ShapeCorners {
      * @param config The configuration limit.
      * @return The clamped value.
      */
-    constexpr static float clamp(const float value, const float delta, const float config) noexcept {
+    constexpr static float clamp(const float value, const float delta, const float config)
+    {
         if (delta > 0 && value > config) {
             return config;
         }
@@ -30,33 +32,35 @@ namespace ShapeCorners {
      * @param value The value to round.
      * @return The rounded value.
      */
-    constexpr static float round(const float value) noexcept {
+    constexpr static float round(const float value)
+    {
         constexpr float ROUNDING_FACTOR = 100.0F; // Factor for rounding to two decimal places
         return std::round(value * ROUNDING_FACTOR) / ROUNDING_FACTOR;
     }
 } // namespace ShapeCorners
 
-ShapeCorners::WindowConfig ShapeCorners::WindowConfig::activeWindowConfig() {
+ShapeCorners::WindowConfig ShapeCorners::WindowConfig::activeWindowConfig()
+{
     const QPalette &m_palette = m_widget.palette();
-    WindowConfig config = {
-            .cornerRadius = static_cast<float>(Config::size()),
-            .shadowSize = static_cast<float>(Config::shadowSize()),
-            .outlineSize = static_cast<float>(Config::outlineThickness()),
-            .secondOutlineSize = static_cast<float>(Config::secondOutlineThickness()),
-            .shadowColor = FloatColor(
+    WindowConfig    config    = {
+                  .cornerRadius      = static_cast<float>(Config::size()),
+                  .shadowSize        = static_cast<float>(Config::shadowSize()),
+                  .outlineSize       = static_cast<float>(Config::outlineThickness()),
+                  .secondOutlineSize = static_cast<float>(Config::secondOutlineThickness()),
+                  .shadowColor       = FloatColor(
                     Config::activeShadowUsePalette()
                             ? m_palette.color(QPalette::Active,
-                                              static_cast<QPalette::ColorRole>(Config::activeShadowPalette()))
+                                                          static_cast<QPalette::ColorRole>(Config::activeShadowPalette()))
                             : Config::shadowColor()),
-            .outlineColor = FloatColor(
+                  .outlineColor = FloatColor(
                     Config::activeOutlineUsePalette()
                             ? m_palette.color(QPalette::Active,
-                                              static_cast<QPalette::ColorRole>(Config::activeOutlinePalette()))
+                                                    static_cast<QPalette::ColorRole>(Config::activeOutlinePalette()))
                             : Config::outlineColor()),
-            .secondOutlineColor = FloatColor(
+                  .secondOutlineColor = FloatColor(
                     Config::activeSecondOutlineUsePalette()
                             ? m_palette.color(QPalette::Active,
-                                              static_cast<QPalette::ColorRole>(Config::activeSecondOutlinePalette()))
+                                                    static_cast<QPalette::ColorRole>(Config::activeSecondOutlinePalette()))
                             : Config::secondOutlineColor()),
     };
     config.shadowColor.setAlpha(Config::activeShadowAlpha());
@@ -65,27 +69,28 @@ ShapeCorners::WindowConfig ShapeCorners::WindowConfig::activeWindowConfig() {
     return config;
 }
 
-ShapeCorners::WindowConfig ShapeCorners::WindowConfig::inactiveWindowConfig() {
+ShapeCorners::WindowConfig ShapeCorners::WindowConfig::inactiveWindowConfig()
+{
     const QPalette &m_palette = m_widget.palette();
-    WindowConfig config = {
-            .cornerRadius = static_cast<float>(Config::inactiveCornerRadius()),
-            .shadowSize = static_cast<float>(Config::inactiveShadowSize()),
-            .outlineSize = static_cast<float>(Config::inactiveOutlineThickness()),
-            .secondOutlineSize = static_cast<float>(Config::inactiveSecondOutlineThickness()),
-            .shadowColor = FloatColor(
+    WindowConfig    config    = {
+                  .cornerRadius      = static_cast<float>(Config::inactiveCornerRadius()),
+                  .shadowSize        = static_cast<float>(Config::inactiveShadowSize()),
+                  .outlineSize       = static_cast<float>(Config::inactiveOutlineThickness()),
+                  .secondOutlineSize = static_cast<float>(Config::inactiveSecondOutlineThickness()),
+                  .shadowColor       = FloatColor(
                     Config::inactiveShadowUsePalette()
                             ? m_palette.color(QPalette::Inactive,
-                                              static_cast<QPalette::ColorRole>(Config::inactiveShadowPalette()))
+                                                          static_cast<QPalette::ColorRole>(Config::inactiveShadowPalette()))
                             : Config::inactiveShadowColor()),
-            .outlineColor = FloatColor(
+                  .outlineColor = FloatColor(
                     Config::inactiveOutlineUsePalette()
                             ? m_palette.color(QPalette::Inactive,
-                                              static_cast<QPalette::ColorRole>(Config::inactiveOutlinePalette()))
+                                                    static_cast<QPalette::ColorRole>(Config::inactiveOutlinePalette()))
                             : Config::inactiveOutlineColor()),
-            .secondOutlineColor = FloatColor(
+                  .secondOutlineColor = FloatColor(
                     Config::inactiveSecondOutlineUsePalette()
                             ? m_palette.color(QPalette::Inactive,
-                                              static_cast<QPalette::ColorRole>(Config::inactiveSecondOutlinePalette()))
+                                                    static_cast<QPalette::ColorRole>(Config::inactiveSecondOutlinePalette()))
                             : Config::inactiveSecondOutlineColor()),
     };
     config.shadowColor.setAlpha(Config::inactiveShadowAlpha());
@@ -94,42 +99,58 @@ ShapeCorners::WindowConfig ShapeCorners::WindowConfig::inactiveWindowConfig() {
     return config;
 }
 
-ShapeCorners::WindowConfig ShapeCorners::WindowConfig::operator+(const WindowConfig &other) const noexcept {
-    return WindowConfig{.cornerRadius = cornerRadius + other.cornerRadius,
-                        .shadowSize = shadowSize + other.shadowSize,
-                        .outlineSize = outlineSize + other.outlineSize,
-                        .secondOutlineSize = secondOutlineSize + other.secondOutlineSize,
-                        .shadowColor = shadowColor + other.shadowColor,
-                        .outlineColor = outlineColor + other.outlineColor,
+ShapeCorners::WindowConfig ShapeCorners::WindowConfig::operator+(const WindowConfig &other) const
+{
+    return WindowConfig{.cornerRadius       = cornerRadius + other.cornerRadius,
+                        .shadowSize         = shadowSize + other.shadowSize,
+                        .outlineSize        = outlineSize + other.outlineSize,
+                        .secondOutlineSize  = secondOutlineSize + other.secondOutlineSize,
+                        .shadowColor        = shadowColor + other.shadowColor,
+                        .outlineColor       = outlineColor + other.outlineColor,
                         .secondOutlineColor = secondOutlineColor + other.secondOutlineColor};
 }
 
-ShapeCorners::WindowConfig ShapeCorners::WindowConfig::operator-(const WindowConfig &other) const noexcept {
-    return WindowConfig{.cornerRadius = cornerRadius - other.cornerRadius,
-                        .shadowSize = shadowSize - other.shadowSize,
-                        .outlineSize = outlineSize - other.outlineSize,
-                        .secondOutlineSize = secondOutlineSize - other.secondOutlineSize,
-                        .shadowColor = shadowColor - other.shadowColor,
-                        .outlineColor = outlineColor - other.outlineColor,
+ShapeCorners::WindowConfig ShapeCorners::WindowConfig::operator-(const WindowConfig &other) const
+{
+    return WindowConfig{.cornerRadius       = cornerRadius - other.cornerRadius,
+                        .shadowSize         = shadowSize - other.shadowSize,
+                        .outlineSize        = outlineSize - other.outlineSize,
+                        .secondOutlineSize  = secondOutlineSize - other.secondOutlineSize,
+                        .shadowColor        = shadowColor - other.shadowColor,
+                        .outlineColor       = outlineColor - other.outlineColor,
                         .secondOutlineColor = secondOutlineColor - other.secondOutlineColor};
 }
 
-ShapeCorners::WindowConfig ShapeCorners::WindowConfig::operator/(const float scalar) const noexcept {
-    return WindowConfig{.cornerRadius = cornerRadius / scalar,
-                        .shadowSize = shadowSize / scalar,
-                        .outlineSize = outlineSize / scalar,
-                        .secondOutlineSize = secondOutlineSize / scalar,
-                        .shadowColor = shadowColor / scalar,
-                        .outlineColor = outlineColor / scalar,
+ShapeCorners::WindowConfig ShapeCorners::WindowConfig::operator*(const float scalar) const
+{
+    return WindowConfig{.cornerRadius       = cornerRadius * scalar,
+                        .shadowSize         = shadowSize * scalar,
+                        .outlineSize        = outlineSize * scalar,
+                        .secondOutlineSize  = secondOutlineSize * scalar,
+                        .shadowColor        = shadowColor * scalar,
+                        .outlineColor       = outlineColor * scalar,
+                        .secondOutlineColor = secondOutlineColor * scalar};
+}
+
+ShapeCorners::WindowConfig ShapeCorners::WindowConfig::operator/(const float scalar) const
+{
+    return WindowConfig{.cornerRadius       = cornerRadius / scalar,
+                        .shadowSize         = shadowSize / scalar,
+                        .outlineSize        = outlineSize / scalar,
+                        .secondOutlineSize  = secondOutlineSize / scalar,
+                        .shadowColor        = shadowColor / scalar,
+                        .outlineColor       = outlineColor / scalar,
                         .secondOutlineColor = secondOutlineColor / scalar};
 }
 
-bool ShapeCorners::WindowConfig::operator!() const noexcept {
-    return cornerRadius <= 0 && shadowSize <= 0 && outlineSize <= 0 && secondOutlineSize <= 0
-         && !shadowColor && !outlineColor && !secondOutlineColor;
+bool ShapeCorners::WindowConfig::operator!() const
+{
+    return cornerRadius <= 0 && shadowSize <= 0 && outlineSize <= 0 && secondOutlineSize <= 0 && !shadowColor &&
+           !outlineColor && !secondOutlineColor;
 }
 
-void ShapeCorners::WindowConfig::operator+=(const WindowConfig &other) noexcept {
+void ShapeCorners::WindowConfig::operator+=(const WindowConfig &other)
+{
     cornerRadius += other.cornerRadius;
     shadowSize += other.shadowSize;
     outlineSize += other.outlineSize;
@@ -139,21 +160,24 @@ void ShapeCorners::WindowConfig::operator+=(const WindowConfig &other) noexcept 
     secondOutlineColor += other.secondOutlineColor;
 }
 
-void ShapeCorners::WindowConfig::round() noexcept {
-    cornerRadius = ShapeCorners::round(cornerRadius);
-    shadowSize = ShapeCorners::round(shadowSize);
-    outlineSize = ShapeCorners::round(outlineSize);
+void ShapeCorners::WindowConfig::round()
+{
+    cornerRadius      = ShapeCorners::round(cornerRadius);
+    shadowSize        = ShapeCorners::round(shadowSize);
+    outlineSize       = ShapeCorners::round(outlineSize);
     secondOutlineSize = ShapeCorners::round(secondOutlineSize);
     shadowColor.round();
     outlineColor.round();
     secondOutlineColor.round();
 }
 
-void ShapeCorners::WindowConfig::clamp(const WindowConfig &direction, const WindowConfig &destination) noexcept {
+void ShapeCorners::WindowConfig::clamp(const WindowConfig &direction, const WindowConfig &destination)
+{
     cornerRadius = ShapeCorners::clamp(cornerRadius, direction.cornerRadius, destination.cornerRadius);
-    shadowSize = ShapeCorners::clamp(shadowSize, direction.shadowSize, destination.shadowSize);
-    outlineSize = ShapeCorners::clamp(outlineSize, direction.outlineSize, destination.outlineSize);
-    secondOutlineSize = ShapeCorners::clamp(secondOutlineSize, direction.secondOutlineSize, destination.secondOutlineSize);
+    shadowSize   = ShapeCorners::clamp(shadowSize, direction.shadowSize, destination.shadowSize);
+    outlineSize  = ShapeCorners::clamp(outlineSize, direction.outlineSize, destination.outlineSize);
+    secondOutlineSize =
+            ShapeCorners::clamp(secondOutlineSize, direction.secondOutlineSize, destination.secondOutlineSize);
     shadowColor.clamp();
     outlineColor.clamp();
     secondOutlineColor.clamp();

--- a/src/WindowConfig.h
+++ b/src/WindowConfig.h
@@ -10,7 +10,8 @@
 
 #include "FloatColor.h"
 
-namespace ShapeCorners {
+namespace ShapeCorners
+{
     /**
      * @struct WindowConfig
      * @brief Stores configuration for a window's appearance and animation.
@@ -71,44 +72,51 @@ namespace ShapeCorners {
          * @param other The other WindowConfig.
          * @return The sum of the two WindowConfigs.
          */
-        WindowConfig operator+(const WindowConfig &other) const noexcept;
+        WindowConfig operator+(const WindowConfig &other) const;
 
         /**
          * @brief Subtracts another WindowConfig from this one.
          * @param other The other WindowConfig.
          * @return The difference of the two WindowConfigs.
          */
-        WindowConfig operator-(const WindowConfig &other) const noexcept;
+        WindowConfig operator-(const WindowConfig &other) const;
+
+        /**
+         * @brief Multiply all fields with a scalar.
+         * @param scalar The scalar value.
+         * @return The scaled WindowConfig.
+         */
+        WindowConfig operator*(float scalar) const;
 
         /**
          * @brief Divides all fields by a scalar.
          * @param scalar The scalar value.
          * @return The scaled WindowConfig.
          */
-        WindowConfig operator/(float scalar) const noexcept;
+        WindowConfig operator/(float scalar) const;
 
         /**
          * @brief Checks if all fields are zero or default.
          * @return True if all fields are zero/default, false otherwise.
          */
-        bool operator!() const noexcept;
+        bool operator!() const;
 
         /**
          * @brief Adds another WindowConfig to this one in-place.
          * @param other The other WindowConfig.
          */
-        void operator+=(const WindowConfig &other) noexcept;
+        void operator+=(const WindowConfig &other);
 
         /**
          * @brief Rounds all floating-point fields to the nearest integer.
          */
-        void round() noexcept;
+        void round();
 
         /**
          * @brief Clamps all fields to the range defined by direction and destination configs.
          * @param direction The direction of change for each field.
          * @param destination The destination config to clamp to.
          */
-        void clamp(const WindowConfig &direction, const WindowConfig &destination) noexcept;
+        void clamp(const WindowConfig &direction, const WindowConfig &destination);
     };
-}
+} // namespace ShapeCorners

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -1,33 +1,35 @@
 #include "WindowManager.h"
-#include "TileChecker.h"
-#include "Window.h"
-#include "Config.h"
+#include <QDBusError>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QtDBus/QDBusConnection>
-#include <QDBusError>
 #include <ranges>
+#include "Config.h"
+#include "TileChecker.h"
+#include "Window.h"
 #if QT_VERSION_MAJOR >= 6
-#include <effect/effectwindow.h>
 #include <effect/effecthandler.h>
+#include <effect/effectwindow.h>
 #else
 #include <kwineffects.h>
 #endif
 
-ShapeCorners::WindowManager::WindowManager() {
+ShapeCorners::WindowManager::WindowManager(const WindowConfig *config)
+{
     // Register D-Bus service and object for external communication
     registerDBus();
-    
+
     // Add all currently stacked windows
     for (const auto &kwindow: KWin::effects->stackingOrder()) {
-        addWindow(kwindow);
+        addWindow(kwindow, config);
     }
-    
+
     // Listen for window deletion events
     connect(KWin::effects, &KWin::EffectsHandler::windowDeleted, this, &WindowManager::windowRemoved);
 }
 
-ShapeCorners::Window *ShapeCorners::WindowManager::findWindow(const KWin::EffectWindow *kwindow) {
+ShapeCorners::Window *ShapeCorners::WindowManager::findWindow(const KWin::EffectWindow *kwindow)
+{
     const auto iterator = m_managed.find(kwindow);
     if (iterator != m_managed.end()) {
         return iterator->second;
@@ -35,7 +37,7 @@ ShapeCorners::Window *ShapeCorners::WindowManager::findWindow(const KWin::Effect
     return nullptr;
 }
 
-bool ShapeCorners::WindowManager::addWindow(KWin::EffectWindow *kwindow)
+bool ShapeCorners::WindowManager::addWindow(KWin::EffectWindow *kwindow, const WindowConfig *config)
 {
     // Don't treat docks as windows. They are needed for the maximized check only.
     if (kwindow->isDock()) {
@@ -63,15 +65,13 @@ bool ShapeCorners::WindowManager::addWindow(KWin::EffectWindow *kwindow)
     }
 
     // Ignore hardcoded exceptions (KWin, lockscreen, etc.)
-    const QSet hardExceptions {
-        QStringLiteral("kwin"),
-        QStringLiteral("kwin_x11"),
-        QStringLiteral("kwin_wayland"),
-        QStringLiteral("kscreenlocker_greet"),
-        QStringLiteral("ksmserver"),
-        QStringLiteral("krunner"),
-        QStringLiteral("ksplashqml"),
-        // QStringLiteral("plasmashell"),        Note: Don't add it to exceptions, it involves widget config windows
+    const QSet hardExceptions{
+            QStringLiteral("kwin"),         QStringLiteral("kwin_x11"),
+            QStringLiteral("kwin_wayland"), QStringLiteral("kscreenlocker_greet"),
+            QStringLiteral("ksmserver"),    QStringLiteral("krunner"),
+            QStringLiteral("ksplashqml"),
+            // QStringLiteral("plasmashell"),        Note: Don't add it to exceptions,
+            // it involves widget config windows
     };
     const auto name = kwindow->windowClass().split(QChar::Space).first();
     if (hardExceptions.contains(name)) {
@@ -82,8 +82,8 @@ bool ShapeCorners::WindowManager::addWindow(KWin::EffectWindow *kwindow)
     }
 
     // Create and add the managed window
-    auto* window = new Window(kwindow);
-    const auto& [iter, r] = m_managed.emplace(kwindow, window);
+    auto *window          = new Window(kwindow, config);
+    const auto &[iter, r] = m_managed.emplace(kwindow, window);
     if (!r) {
 #ifdef QT_DEBUG
         qWarning() << "ShapeCorners: ignoring duplicate window.";
@@ -97,7 +97,7 @@ bool ShapeCorners::WindowManager::addWindow(KWin::EffectWindow *kwindow)
 #else
     connect(KWin::effects, &KWin::EffectsHandler::windowFrameGeometryChanged, this, &WindowManager::windowResized);
 #endif
-    
+
     // Update tiling and maximized state for the new window
     windowResized(kwindow, QRectF());
     return true;
@@ -107,20 +107,17 @@ void ShapeCorners::WindowManager::windowRemoved(KWin::EffectWindow *kwindow)
 {
     if (kwindow == nullptr) {
         qDebug() << "ShapeCorners: null window removed";
-    }
-    else if (const auto iterator = m_managed.find(kwindow); iterator != m_managed.end()) {
+    } else if (const auto iterator = m_managed.find(kwindow); iterator != m_managed.end()) {
         iterator->second->deleteLater();
         m_managed.erase(iterator);
         qDebug() << "ShapeCorners: window removed" << kwindow->windowClass();
-    }
-    else if (const auto iterator2 = std::ranges::find(m_menuBars, kwindow); iterator2 != m_menuBars.end()) {
+    } else if (const auto iterator2 = std::ranges::find(m_menuBars, kwindow); iterator2 != m_menuBars.end()) {
         m_menuBars.erase(iterator2);
         qDebug() << "ShapeCorners: menu removed" << kwindow->windowClass();
 
         // Changes in menu bars can change the maximized state of all windows
         checkMaximized();
-    }
-    else {
+    } else {
         qDebug() << "ShapeCorners: excluded window removed" << kwindow->windowClass();
     }
 
@@ -128,7 +125,8 @@ void ShapeCorners::WindowManager::windowRemoved(KWin::EffectWindow *kwindow)
     checkTiled();
 }
 
-QString ShapeCorners::WindowManager::get_window_titles() const {
+QString ShapeCorners::WindowManager::get_window_titles() const
+{
     QJsonArray array;
     for (const auto &window: m_managed | std::views::values) {
         auto json = window->toJson();
@@ -140,7 +138,8 @@ QString ShapeCorners::WindowManager::get_window_titles() const {
     return QString::fromUtf8(doc);
 }
 
-void ShapeCorners::WindowManager::registerDBus() {
+void ShapeCorners::WindowManager::registerDBus()
+{
     auto connection = QDBusConnection::sessionBus();
     if (!connection.isConnected()) {
         qWarning() << "ShapeCorners: Cannot connect to the D-Bus session bus.";
@@ -156,8 +155,9 @@ void ShapeCorners::WindowManager::registerDBus() {
     }
 }
 
-void ShapeCorners::WindowManager::checkTiled() {
-    TileChecker tileChecker (m_managed);
+void ShapeCorners::WindowManager::checkTiled()
+{
+    TileChecker tileChecker(m_managed);
     tileChecker.clearTiles();
 
     // If both tile options are disabled, skip checking
@@ -166,14 +166,15 @@ void ShapeCorners::WindowManager::checkTiled() {
     }
 
     // Check tiling for each screen, excluding menu bars
-    for (const auto& screen: KWin::effects->screens()) {
+    for (const auto &screen: KWin::effects->screens()) {
         const auto screen_region = getRegionWithoutMenus(screen->geometry());
-        const auto geometry = screen_region.boundingRect();
+        const auto geometry      = screen_region.boundingRect();
         tileChecker.checkTiles(geometry);
     }
 }
 
-QRegion ShapeCorners::WindowManager::getRegionWithoutMenus(const QRect& screen_geometry) const {
+QRegion ShapeCorners::WindowManager::getRegionWithoutMenus(const QRect &screen_geometry) const
+{
     auto screen_region = QRegion(screen_geometry);
 #ifdef DEBUG_MAXIMIZED
     qDebug() << "ShapeCorners: screen region" << screen_region;
@@ -194,8 +195,9 @@ QRegion ShapeCorners::WindowManager::getRegionWithoutMenus(const QRect& screen_g
     return screen_region;
 }
 
-void ShapeCorners::WindowManager::checkMaximized(KWin::EffectWindow *kwindow) {
-    auto* const window = findWindow(kwindow);
+void ShapeCorners::WindowManager::checkMaximized(KWin::EffectWindow *kwindow)
+{
+    auto *const window = findWindow(kwindow);
     if (window == nullptr) {
         return;
     }
@@ -225,8 +227,9 @@ void ShapeCorners::WindowManager::windowResized(KWin::EffectWindow *kwindow, con
     checkMaximized(kwindow);
 }
 
-void ShapeCorners::WindowManager::checkMaximized() {
-    for (auto* window: m_managed | std::views::values) {
+void ShapeCorners::WindowManager::checkMaximized()
+{
+    for (const auto *window: m_managed | std::views::values) {
         checkMaximized(window->w);
     }
 }

--- a/src/WindowManager.h
+++ b/src/WindowManager.h
@@ -12,23 +12,26 @@
 #include <unordered_map>
 #include <vector>
 
-namespace KWin {
+namespace KWin
+{
     class EffectWindow;
 }
 
-namespace ShapeCorners {
+namespace ShapeCorners
+{
     class Window;
+    class WindowConfig;
 
     /**
      * @brief Alias for a map of managed windows.
      * Maps KWin::EffectWindow pointers to ShapeCorners::Window pointers.
      */
-    using WindowList = std::unordered_map<const KWin::EffectWindow*, Window*>;
+    using WindowList = std::unordered_map<const KWin::EffectWindow *, Window *>;
 
     /**
      * @brief Alias for a vector of managed menus.
      */
-    using MenuBarList = std::vector<const KWin::EffectWindow*>;
+    using MenuBarList = std::vector<const KWin::EffectWindow *>;
 
     /**
      * @class WindowManager
@@ -37,40 +40,42 @@ namespace ShapeCorners {
      * Handles adding/removing windows, tracking menu bars, checking tiling and maximization,
      * and provides a D-Bus interface for querying window information.
      */
-    class WindowManager final: public QObject {
+    class WindowManager final : public QObject
+    {
         Q_OBJECT
 
     public:
         /**
          * @brief Constructs the WindowManager, registers D-Bus, and adds existing windows.
          */
-        WindowManager();
+        explicit WindowManager(const WindowConfig *config);
 
         /**
          * @brief Finds a managed window by its EffectWindow pointer.
          * @param kwindow The EffectWindow to search for.
          * @return Pointer to the managed Window, or nullptr if not found.
          */
-        Window* findWindow(const KWin::EffectWindow *kwindow);
+        Window *findWindow(const KWin::EffectWindow *kwindow);
 
         /**
          * @brief Checks and adds a window to management, or as a menu bar if it's a dock.
          * @param kwindow The EffectWindow to add.
-         * 
+         * @param config The initial config of the window.
+         *
          * @return True if a new managed window was added, false if:
-         * 
+         *
          * - The window is a dock (added as a menu bar instead)
-         * 
+         *
          * - The window has an empty class and caption
-         * 
+         *
          * - The window matches a hardcoded exception (e.g., KWin, lockscreen, etc.)
-         * 
+         *
          * - The window is already managed (duplicate)
          */
-        bool addWindow(KWin::EffectWindow *kwindow);
+        bool addWindow(KWin::EffectWindow *kwindow, const WindowConfig *config);
 
     public Q_SLOTS:
-        
+
         /**
          * @brief Returns a JSON string of all managed window titles and classes.
          * It is being used by the D-Bus interface.
@@ -131,8 +136,7 @@ namespace ShapeCorners {
          * @param screen_geometry The geometry of the screen.
          * @return QRegion without menu bars.
          */
-        [[nodiscard]] 
-        QRegion getRegionWithoutMenus(const QRect& screen_geometry) const;
-
+        [[nodiscard]]
+        QRegion getRegionWithoutMenus(const QRect &screen_geometry) const;
     };
-}
+} // namespace ShapeCorners

--- a/src/kcm/KCM.cpp
+++ b/src/kcm/KCM.cpp
@@ -1,21 +1,18 @@
 #include "KCM.h"
-#include "ui_KCM.h"
 #include "kwineffects_interface.h"
+#include "ui_KCM.h"
 
 #if (QT_VERSION_MAJOR >= 6)
-ShapeCorners::KCM::KCM(QObject* parent, const KPluginMetaData& args)
-    : KCModule(parent, args)
-    , ui(new Ui::Form)
+ShapeCorners::KCM::KCM(QObject *parent, const KPluginMetaData &args) : KCModule(parent, args), ui(new Ui::Form)
 {
     // Set up the UI for Qt 6
-    ui->setupUi(widget());
+    ui->setupUi(KCModule::widget());
+    ui->widget->setFixedSize(800, 672);
     ui->currentWindowList->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
-    addConfig(&config, widget());
+    addConfig(&config, KCModule::widget());
 
 #else
-ShapeCorners::KCM::KCM(QWidget* parent, const QVariantList& args)
-    : KCModule(parent, args)
-    , ui(new Ui::Form)
+ShapeCorners::KCM::KCM(QWidget *parent, const QVariantList &args) : KCModule(parent, args), ui(new Ui::Form)
 {
     // Set up the UI for Qt 5
     ui->setupUi(this);
@@ -27,56 +24,62 @@ ShapeCorners::KCM::KCM(QWidget* parent, const QVariantList& args)
     update_windows();
 
     // Set icons for palette combo boxes based on current palette colors
-    const int size = 16;
-    QPixmap pix (size, size);
+    constexpr int size = 16;
+    QPixmap       pix(size, size);
     for (int index = 0; index < ui->kcfg_ActiveOutlinePalette->count(); ++index) {
         auto color = palette().color(QPalette::Active, static_cast<QPalette::ColorRole>(index));
         pix.fill(color);
-        QIcon icon (pix);
+        QIcon icon(pix);
         ui->kcfg_ActiveOutlinePalette->setItemIcon(index, icon);
         ui->kcfg_ActiveSecondOutlinePalette->setItemIcon(index, icon);
         ui->kcfg_ActiveShadowPalette->setItemIcon(index, icon);
 
         color = palette().color(QPalette::Inactive, static_cast<QPalette::ColorRole>(index));
         pix.fill(color);
-        QIcon icon2 (pix);
+        QIcon icon2(pix);
         ui->kcfg_InactiveOutlinePalette->setItemIcon(index, icon2);
         ui->kcfg_InactiveSecondOutlinePalette->setItemIcon(index, icon2);
         ui->kcfg_InactiveShadowPalette->setItemIcon(index, icon2);
     }
 
     // Connect UI signals to slots for color and palette changes
-    connect(ui->kcfg_ActiveOutlinePalette, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &KCM::update_colors);
-    connect(ui->kcfg_InactiveOutlinePalette, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &KCM::update_colors);
+    connect(ui->kcfg_ActiveOutlinePalette, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+            &KCM::update_colors);
+    connect(ui->kcfg_InactiveOutlinePalette, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+            &KCM::update_colors);
     connect(ui->kcfg_OutlineColor, &KColorButton::changed, this, &KCM::update_colors);
     connect(ui->kcfg_InactiveOutlineColor, &KColorButton::changed, this, &KCM::update_colors);
     connect(ui->kcfg_ActiveOutlineUsePalette, &QRadioButton::toggled, this, &KCM::update_colors);
     connect(ui->kcfg_InactiveOutlineUsePalette, &QRadioButton::toggled, this, &KCM::update_colors);
 
-    connect(ui->kcfg_ActiveSecondOutlinePalette, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &KCM::update_colors);
-    connect(ui->kcfg_InactiveSecondOutlinePalette, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &KCM::update_colors);
+    connect(ui->kcfg_ActiveSecondOutlinePalette, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+            &KCM::update_colors);
+    connect(ui->kcfg_InactiveSecondOutlinePalette, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+            &KCM::update_colors);
     connect(ui->kcfg_SecondOutlineColor, &KColorButton::changed, this, &KCM::update_colors);
     connect(ui->kcfg_InactiveSecondOutlineColor, &KColorButton::changed, this, &KCM::update_colors);
     connect(ui->kcfg_ActiveSecondOutlineUsePalette, &QRadioButton::toggled, this, &KCM::update_colors);
     connect(ui->kcfg_InactiveSecondOutlineUsePalette, &QRadioButton::toggled, this, &KCM::update_colors);
 
-    connect(ui->kcfg_ActiveShadowPalette, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &KCM::update_colors);
-    connect(ui->kcfg_ActiveShadowPalette, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &KCM::update_colors);
+    connect(ui->kcfg_ActiveShadowPalette, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+            &KCM::update_colors);
+    connect(ui->kcfg_ActiveShadowPalette, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+            &KCM::update_colors);
     connect(ui->kcfg_ShadowColor, &KColorButton::changed, this, &KCM::update_colors);
     connect(ui->kcfg_InactiveShadowColor, &KColorButton::changed, this, &KCM::update_colors);
     connect(ui->kcfg_ActiveShadowUsePalette, &QRadioButton::toggled, this, &KCM::update_colors);
     connect(ui->kcfg_InactiveShadowUsePalette, &QRadioButton::toggled, this, &KCM::update_colors);
-    
+
     // Enable/disable shadow controls based on native decoration shadow usage
     connect(ui->kcfg_UseNativeDecorationShadows, &QRadioButton::toggled, [=, this] {
-        const auto& useCustomShadows = !ui->kcfg_UseNativeDecorationShadows->isChecked();
+        const auto &useCustomShadows = !ui->kcfg_UseNativeDecorationShadows->isChecked();
         ui->UseCustomShadows->setChecked(useCustomShadows);
         ui->activeShadowGroupBox->setEnabled(useCustomShadows);
         ui->inactiveShadowGroupBox->setEnabled(useCustomShadows);
     });
 
-    // It was expected that the Apply button would get enabled automatically as the gradient sliders move, but it doesn't.
-    // Maybe it is a bug on the KCM side. Need to check and delete these lines later.
+    // It was expected that the Apply button would get enabled automatically as the gradient sliders move, but it
+    // doesn't. Maybe it is a bug on the KCM side. Need to check and delete these lines later.
     connect(ui->kcfg_ActiveShadowAlpha, &KGradientSelector::sliderMoved, this, &KCM::markAsChanged);
     connect(ui->kcfg_InactiveShadowAlpha, &KGradientSelector::sliderMoved, this, &KCM::markAsChanged);
     connect(ui->kcfg_ActiveOutlineAlpha, &KGradientSelector::sliderMoved, this, &KCM::markAsChanged);
@@ -92,16 +95,18 @@ ShapeCorners::KCM::KCM(QWidget* parent, const QVariantList& args)
     connect(ui->refreshButton, &QPushButton::pressed, this, &KCM::update_windows);
     connect(ui->includeButton, &QPushButton::pressed, [=, this]() {
         // Add selected window to inclusion list if not already present
-        if (auto* const item = ui->currentWindowList->currentItem();
-            item != nullptr && !item->text().isEmpty() && ui->InclusionList->findItems(item->text(), Qt::MatchExactly).empty()) {
+        if (const auto *const item = ui->currentWindowList->currentItem();
+            item != nullptr && !item->text().isEmpty() &&
+            ui->InclusionList->findItems(item->text(), Qt::MatchExactly).empty()) {
             ui->InclusionList->addItem(item->text());
             markAsChanged();
         }
     });
     connect(ui->excludeButton, &QPushButton::pressed, [=, this]() {
         // Add selected window to exclusion list if not already present
-        if (auto* const item = ui->currentWindowList->currentItem();
-            item != nullptr && !item->text().isEmpty() && ui->ExclusionList->findItems(item->text(), Qt::MatchExactly).empty()) {
+        if (const auto *const item = ui->currentWindowList->currentItem();
+            item != nullptr && !item->text().isEmpty() &&
+            ui->ExclusionList->findItems(item->text(), Qt::MatchExactly).empty()) {
             ui->ExclusionList->addItem(item->text());
             markAsChanged();
         }
@@ -116,10 +121,15 @@ ShapeCorners::KCM::KCM(QWidget* parent, const QVariantList& args)
         ui->ExclusionList->takeItem(ui->ExclusionList->currentRow());
         markAsChanged();
     });
+
+    // Enable/disable animation
+    connect(ui->AnimationCheckbox, &QRadioButton::toggled, [=, this] {
+        ui->kcfg_AnimationDuration->setEnabled(ui->AnimationCheckbox->isChecked());
+        markAsChanged();
+    });
 }
 
-void
-ShapeCorners::KCM::save()
+void ShapeCorners::KCM::save()
 {
     // Gather inclusion list from UI and save to config
     QStringList inclusions;
@@ -127,7 +137,7 @@ ShapeCorners::KCM::save()
         inclusions.push_back(ui->InclusionList->item(i)->text());
     }
     config.setInclusions(inclusions);
-    
+
     // Gather exclusion list from UI and save to config
     QStringList exclusions;
     for (int i = 0; i < ui->ExclusionList->count(); ++i) {
@@ -135,14 +145,18 @@ ShapeCorners::KCM::save()
     }
     config.setExclusions(exclusions);
 
+    // Set animation duration based on its checkbox
+    if (!ui->kcfg_AnimationDuration->isEnabled()) {
+        config.setAnimationDuration(0);
+    }
+
     qDebug() << "ShapeCorners: Saving configurations";
     config.save();
     KCModule::save();
 
     // Notify KWin to reload the effect configuration via DBus
-    const auto dbusName = QStringLiteral("kwin4_effect_shapecorners");
-    OrgKdeKwinEffectsInterface interface(QStringLiteral("org.kde.KWin"),
-                                         QStringLiteral("/Effects"),
+    const auto                 dbusName = QStringLiteral("kwin4_effect_shapecorners");
+    OrgKdeKwinEffectsInterface interface(QStringLiteral("org.kde.KWin"), QStringLiteral("/Effects"),
                                          QDBusConnection::sessionBus());
     interface.reconfigureEffect(dbusName);
 
@@ -156,57 +170,67 @@ ShapeCorners::KCM::save()
     load();
 }
 
-void ShapeCorners::KCM::update_colors() {
+void ShapeCorners::KCM::update_colors()
+{
     QColor color;
-    bool checked;
-    int index;
+    bool   checked;
+    int    index;
 
     // Update active outline color preview
     checked = ui->kcfg_ActiveOutlineUsePalette->isChecked();
-    index = ui->kcfg_ActiveOutlinePalette->currentIndex();
-    color = checked ? palette().color(QPalette::Active, static_cast<QPalette::ColorRole>(index)): ui->kcfg_OutlineColor->color();
+    index   = ui->kcfg_ActiveOutlinePalette->currentIndex();
+    color   = checked ? palette().color(QPalette::Active, static_cast<QPalette::ColorRole>(index))
+                      : ui->kcfg_OutlineColor->color();
     ui->kcfg_ActiveOutlineAlpha->setSecondColor(color);
 
     // Update inactive outline color preview
     checked = ui->kcfg_InactiveOutlineUsePalette->isChecked();
-    index = ui->kcfg_InactiveOutlinePalette->currentIndex();
-    color = checked ? palette().color(QPalette::Inactive, static_cast<QPalette::ColorRole>(index)): ui->kcfg_InactiveOutlineColor->color();
+    index   = ui->kcfg_InactiveOutlinePalette->currentIndex();
+    color   = checked ? palette().color(QPalette::Inactive, static_cast<QPalette::ColorRole>(index))
+                      : ui->kcfg_InactiveOutlineColor->color();
     ui->kcfg_InactiveOutlineAlpha->setSecondColor(color);
 
     // Update active second outline color preview
     checked = ui->kcfg_ActiveSecondOutlineUsePalette->isChecked();
-    index = ui->kcfg_ActiveSecondOutlinePalette->currentIndex();
-    color = checked ? palette().color(QPalette::Active, static_cast<QPalette::ColorRole>(index)): ui->kcfg_SecondOutlineColor->color();
+    index   = ui->kcfg_ActiveSecondOutlinePalette->currentIndex();
+    color   = checked ? palette().color(QPalette::Active, static_cast<QPalette::ColorRole>(index))
+                      : ui->kcfg_SecondOutlineColor->color();
     ui->kcfg_ActiveSecondOutlineAlpha->setSecondColor(color);
 
     // Update inactive second outline color preview
     checked = ui->kcfg_InactiveSecondOutlineUsePalette->isChecked();
-    index = ui->kcfg_InactiveSecondOutlinePalette->currentIndex();
-    color = checked ? palette().color(QPalette::Inactive, static_cast<QPalette::ColorRole>(index)): ui->kcfg_InactiveSecondOutlineColor->color();
+    index   = ui->kcfg_InactiveSecondOutlinePalette->currentIndex();
+    color   = checked ? palette().color(QPalette::Inactive, static_cast<QPalette::ColorRole>(index))
+                      : ui->kcfg_InactiveSecondOutlineColor->color();
     ui->kcfg_InactiveSecondOutlineAlpha->setSecondColor(color);
 
     // Update active shadow color preview
     checked = ui->kcfg_ActiveShadowUsePalette->isChecked();
-    index = ui->kcfg_ActiveShadowPalette->currentIndex();
-    color = checked ? palette().color(QPalette::Active, static_cast<QPalette::ColorRole>(index)): ui->kcfg_ShadowColor->color();
+    index   = ui->kcfg_ActiveShadowPalette->currentIndex();
+    color   = checked ? palette().color(QPalette::Active, static_cast<QPalette::ColorRole>(index))
+                      : ui->kcfg_ShadowColor->color();
     ui->kcfg_ActiveShadowAlpha->setSecondColor(color);
 
     // Update inactive shadow color preview
     checked = ui->kcfg_InactiveShadowUsePalette->isChecked();
-    index = ui->kcfg_InactiveShadowPalette->currentIndex();
-    color = checked ? palette().color(QPalette::Inactive, static_cast<QPalette::ColorRole>(index)): ui->kcfg_InactiveShadowColor->color();
+    index   = ui->kcfg_InactiveShadowPalette->currentIndex();
+    color   = checked ? palette().color(QPalette::Inactive, static_cast<QPalette::ColorRole>(index))
+                      : ui->kcfg_InactiveShadowColor->color();
     ui->kcfg_InactiveShadowAlpha->setSecondColor(color);
 }
 
-void ShapeCorners::KCM::update_windows() const {
+void ShapeCorners::KCM::update_windows() const
+{
     QJsonArray array;
     // Query the ShapeCorners effect for the list of open windows via DBus
     if (const auto connection = QDBusConnection::sessionBus(); connection.isConnected()) {
-        if (QDBusInterface interface(QStringLiteral("org.kde.ShapeCorners"), QStringLiteral("/ShapeCornersEffect")); interface.isValid()) {
-            if (const QDBusReply<QString> reply = interface.call(QStringLiteral("get_window_titles")); reply.isValid()) {
-                auto str = reply.value();
-                auto doc = QJsonDocument::fromJson(str.toUtf8());
-                array = doc.array();
+        if (QDBusInterface interface(QStringLiteral("org.kde.ShapeCorners"), QStringLiteral("/ShapeCornersEffect"));
+            interface.isValid()) {
+            if (const QDBusReply<QString> reply = interface.call(QStringLiteral("get_window_titles"));
+                reply.isValid()) {
+                const auto str = reply.value();
+                const auto doc = QJsonDocument::fromJson(str.toUtf8());
+                array          = doc.array();
             }
         }
     }
@@ -215,18 +239,18 @@ void ShapeCorners::KCM::update_windows() const {
     ui->currentWindowList->clear();
     ui->currentWindowList->setRowCount(static_cast<int>(array.size()));
     ui->currentWindowList->setColumnCount(3);
-    ui->currentWindowList->setHorizontalHeaderLabels({
-        QStringLiteral("Class 1"), QStringLiteral("Class 2"), QStringLiteral("Caption") });
+    ui->currentWindowList->setHorizontalHeaderLabels(
+            {QStringLiteral("Class 1"), QStringLiteral("Class 2"), QStringLiteral("Caption")});
 
     // Fill the table with window class and caption data
-    for (int i=0; i < array.size(); ++i) {
-        const auto obj = array.at(i).toObject();
+    for (int i = 0; i < array.size(); ++i) {
+        const auto obj         = array.at(i).toObject();
         const auto windowClass = obj.value(QStringLiteral("class")).toString();
-        const auto caption = obj.value(QStringLiteral("caption")).toString();
+        const auto caption     = obj.value(QStringLiteral("caption")).toString();
 
-        const auto windowClassSplit = windowClass.split(QChar(QChar::Space));
-        const auto& class1 = windowClassSplit.at(0);
-        const auto& class2 = windowClassSplit.at(1);
+        const auto  windowClassSplit = windowClass.split(QChar(QChar::Space));
+        const auto &class1           = windowClassSplit.at(0);
+        const auto &class2           = windowClassSplit.at(1);
 
         ui->currentWindowList->setItem(i, 0, new QTableWidgetItem(class1));
         ui->currentWindowList->setItem(i, 1, new QTableWidgetItem(class2));
@@ -234,8 +258,9 @@ void ShapeCorners::KCM::update_windows() const {
     }
 }
 
-void ShapeCorners::KCM::outline_group_toggled(bool value) const {
-    const float outlineThicknessMin = 0.75F;
+void ShapeCorners::KCM::outline_group_toggled(const bool value) const
+{
+    constexpr float outlineThicknessMin = 0.75F;
     // Enable or disable outline thickness based on group toggle
     if (sender() == ui->primaryOutline) {
         ui->kcfg_OutlineThickness->setValue(value ? outlineThicknessMin : 0);
@@ -246,14 +271,16 @@ void ShapeCorners::KCM::outline_group_toggled(bool value) const {
     }
 }
 
-void ShapeCorners::KCM::load() {
+void ShapeCorners::KCM::load()
+{
     // Load settings from config and update UI
     KCModule::load();
     config.load();
     load_ui();
 }
 
-void ShapeCorners::KCM::defaults() {
+void ShapeCorners::KCM::defaults()
+{
     // Reset settings to defaults and update UI
     KCModule::defaults();
     config.setDefaults();
@@ -261,7 +288,8 @@ void ShapeCorners::KCM::defaults() {
     markAsChanged();
 }
 
-void ShapeCorners::KCM::load_ui() const {
+void ShapeCorners::KCM::load_ui() const
+{
     // Clear and repopulate inclusion/exclusion lists from config
     ui->InclusionList->clear();
     ui->ExclusionList->clear();
@@ -272,4 +300,7 @@ void ShapeCorners::KCM::load_ui() const {
     // Set outline group checkboxes based on thickness values
     ui->primaryOutline->setChecked(ui->kcfg_OutlineThickness->value() > 0);
     ui->secondaryOutline->setChecked(ui->kcfg_SecondOutlineThickness->value() > 0);
+
+    // Set animation checkboxes based on its duration
+    ui->AnimationCheckbox->setChecked(config.animationDuration() > 0);
 }

--- a/src/kcm/KCM.h
+++ b/src/kcm/KCM.h
@@ -39,7 +39,7 @@ namespace ShapeCorners {
         explicit KCM(QWidget* parent = nullptr, const QVariantList& args = QVariantList());
 #endif
 
-    public Q_SLOTS:
+    private Q_SLOTS:
         /**
          * @brief Resets the settings to their default values.
          */

--- a/src/kcm/KCM.ui
+++ b/src/kcm/KCM.ui
@@ -2,33 +2,63 @@
 <ui version="4.0">
  <class>Form</class>
  <widget class="QWidget" name="Form">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>700</width>
-    <height>670</height>
-   </rect>
-  </property>
-  <property name="minimumSize">
-   <size>
-    <width>700</width>
-    <height>670</height>
-   </size>
-  </property>
   <property name="windowTitle">
    <string>Rounded Corners (formerly ShapeCorners)</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_4">
    <item>
-    <widget class="QCheckBox" name="kcfg_AnimationEnabled">
-     <property name="text">
-      <string>Enable animation between active and inactive state</string>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
-    </widget>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QCheckBox" name="AnimationCheckbox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Animate transition between active and inactive states with duration:</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QDoubleSpinBox" name="kcfg_AnimationDuration">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>85</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="showGroupSeparator" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="suffix">
+        <string>ms</string>
+       </property>
+       <property name="decimals">
+        <number>0</number>
+       </property>
+       <property name="maximum">
+        <double>2000.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>50.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>250.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <widget class="QTabWidget" name="tabWidget">
@@ -124,6 +154,9 @@
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Orientation::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Policy::MinimumExpanding</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -631,6 +664,9 @@
         <spacer name="verticalSpacer_3">
          <property name="orientation">
           <enum>Qt::Orientation::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Policy::MinimumExpanding</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -1607,6 +1643,9 @@
         <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Orientation::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Policy::MinimumExpanding</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>

--- a/src/kcm/options.kcfg
+++ b/src/kcm/options.kcfg
@@ -12,8 +12,10 @@
         <entry name="InactiveCornerRadius" type="UInt">
             <default>10</default>
         </entry>
-        <entry name="AnimationEnabled" type="Bool">
-            <default>true</default>
+        <entry name="AnimationDuration" type="UInt">
+            <default>250</default>
+            <min>0</min>
+            <max>2000</max>
         </entry>
 
         <!-- Shadow Options -->

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -8,7 +8,8 @@
 
 #include "Effect.h"
 
-namespace ShapeCorners {
+namespace ShapeCorners
+{
     Q_NAMESPACE
 
     /**
@@ -17,9 +18,7 @@ namespace ShapeCorners {
      * Uses the KWIN_EFFECT_FACTORY_SUPPORTED macro to register the Effect class,
      * specifying the metadata file and the support check.
      */
-    KWIN_EFFECT_FACTORY_SUPPORTED(Effect,
-                                  "metadata.json",
-                                  return Effect::supported();)
-}
+    KWIN_EFFECT_FACTORY_SUPPORTED(Effect, "metadata.json", return Effect::supported();)
+} // namespace ShapeCorners
 
 #include "plugin.moc"


### PR DESCRIPTION
This pull request is addressing a couple of issues in the previous implementation of window state transition animation:

- It wasn't using a time duration. It was running based on the desktop refresh rates; it ran faster at 60 Hz compared to 30 Hz. Now it uses a time duration adjusted in the configuration. This leads to a consistent animation, but smoother at higher refresh rates.
- It was using a config comparison to determine if the animation had reached the expected result. This means the slight difference between the active and inactive states was being done faster than the bigger difference. Now it is using a fixed time, and the transition will be spread over that time duration, no matter the difference.
- It was animating in a non-linear transition. Now it is running on a linear transition.
- Each window was running the exact same interpolation and the exact same copy of the result. This leads to unnecessary CPU and memory usage (100 windows -> 100 CPU calculations and 100 configs in memory). Now the interpolation is being done only once and shared with every active and inactive window. (100 windows -> 1 CPU calculation and 2 configs in memory)