### PR TITLE
Detect active window changes without signals

### DIFF
--- a/src/Animation.cpp
+++ b/src/Animation.cpp
@@ -20,12 +20,15 @@ ShapeCorners::Animation::Animation() : lastAnimationDuration(Config::animationDu
 {
     // Initialize animation state.
     update();
-    // Connect to window activation signal to handle active window changes.
-    connect(KWin::effects, &KWin::EffectsHandler::windowActivated, this, &Animation::setActiveWindowChanged);
 }
 
 void ShapeCorners::Animation::update()
 {
+    if (const auto active = KWin::effects->activeWindow(); active != lastActiveWindow) {
+        setActiveWindowChanged(active);
+        lastActiveWindow = active;
+    }
+
     // If not animating, skip update.
     if (!m_isAnimating) {
         return;

--- a/src/Animation.h
+++ b/src/Animation.h
@@ -23,9 +23,8 @@ namespace ShapeCorners
      * Handles the transition between active and inactive window configurations,
      * updating animation progress and responding to window activation changes.
      */
-    class Animation final : public QObject
+    class Animation
     {
-        Q_OBJECT
 
     public:
         /**
@@ -78,14 +77,13 @@ namespace ShapeCorners
          */
         void update();
 
-    private Q_SLOTS:
+    private:
         /**
          * @brief Handles changes to the active window.
          * @param w The newly activated EffectWindow.
          */
         void setActiveWindowChanged(const KWin::EffectWindow *w);
 
-    private:
         /// Duration remaining for the current animation, in milliseconds.
         long lastAnimationDuration;
 
@@ -94,6 +92,9 @@ namespace ShapeCorners
 
         /// Timestamp of the last active window change.
         std::chrono::system_clock::time_point lastActiveWindowChangedTime;
+
+        /// Pointer to the last active window, only used to detect changes.
+        KWin::EffectWindow * lastActiveWindow = nullptr;
 
         /// Interpolated configuration for the active window.
         WindowConfig activeAnimation;


### PR DESCRIPTION
It ensures that changes to the active window are consistently detected by polling the active window and comparing it to the last active window.

This may improve the reliability of handling active window changes raised in #399.