### PR TITLE
Update the animation logic again

### DIFF
--- a/src/Animation.h
+++ b/src/Animation.h
@@ -4,19 +4,9 @@
 
 #pragma once
 
-#include <QObject>
-#include <chrono>
-#include "WindowConfig.h"
-
-namespace KWin
-{
-    class EffectWindow;
-}
-
 namespace ShapeCorners
 {
     class Window;
-
     /**
      * @brief Manages animation state and configuration for window corner effects.
      *
@@ -25,7 +15,6 @@ namespace ShapeCorners
      */
     class Animation
     {
-
     public:
         /**
          * @brief Initializes the animation state and connects activation signals.
@@ -33,74 +22,23 @@ namespace ShapeCorners
         Animation();
 
         /**
-         * @brief Gets the current frame configuration for a window.
-         * @param window The window to query.
-         * @return Pointer to the appropriate WindowConfig for the window's state.
-         */
-        [[nodiscard]]
-        const WindowConfig *getFrameConfig(const Window &window) const;
-
-        /**
-         * @brief Gets the current configuration for the active window.
-         * @return Pointer to the active WindowConfig.
-         */
-        [[nodiscard]]
-        const WindowConfig *getActiveConfig() const
-        {
-            return &activeAnimation;
-        }
-
-        /**
-         * @brief Gets the current configuration for inactive windows.
-         * @return Pointer to the inactive WindowConfig.
-         */
-        [[nodiscard]]
-        const WindowConfig *getInactiveConfig() const
-        {
-            return &inactiveAnimation;
-        }
-
-        /**
-         * @brief Checks if an animation is currently in progress.
-         * @return True if animating, false otherwise.
-         */
-        [[nodiscard]]
-        bool isAnimating() const
-        {
-            return m_isAnimating;
-        }
-
-        /**
          * @brief Updates the animation state and interpolates configurations.
-         *
+         * @param window The Window object to update.
          * Should be called regularly to progress the animation.
          */
-        void update();
+        void update(Window &window);
 
     private:
         /**
          * @brief Handles changes to the active window.
-         * @param w The newly activated EffectWindow.
+         * @param window The newly activated EffectWindow. Null if no window is active.
          */
-        void setActiveWindowChanged(const KWin::EffectWindow *w);
+        void setActiveWindowChanged(Window *window);
 
-        /// Duration remaining for the current animation, in milliseconds.
-        long lastAnimationDuration;
-
-        /// Whether an animation is currently running.
-        bool m_isAnimating = true;
-
-        /// Timestamp of the last active window change.
-        std::chrono::system_clock::time_point lastActiveWindowChangedTime;
+        /// Pointer to the current active window, only used to detect changes.
+        Window *currentActiveWindow = nullptr;
 
         /// Pointer to the last active window, only used to detect changes.
-        KWin::EffectWindow * lastActiveWindow = nullptr;
-
-        /// Interpolated configuration for the active window.
-        WindowConfig activeAnimation;
-
-        /// Interpolated configuration for inactive windows.
-        WindowConfig inactiveAnimation;
+        Window *lastActiveWindow = nullptr;
     };
-
 } // namespace ShapeCorners

--- a/src/Effect.cpp
+++ b/src/Effect.cpp
@@ -112,7 +112,7 @@ void ShapeCorners::Effect::prePaintWindow(KWin::EffectWindow *kwindow, KWin::Win
 #else
         // Calculate geometry and corner size for Qt5.
         const auto geo  = kwindow->frameGeometry() * KWin::effects->renderTargetScale();
-        const auto size = window->currentConfig->cornerRadius * KWin::effects->renderTargetScale();
+        const auto size = window->currentConfig.cornerRadius * KWin::effects->renderTargetScale();
 #endif
 
         // Create a region for each rounded corner.

--- a/src/Effect.h
+++ b/src/Effect.h
@@ -68,13 +68,6 @@ namespace ShapeCorners
         void reconfigure(ReconfigureFlags flags) override;
 
         /**
-         * @brief Prepares the screen for painting.
-         * @param data The screen pre-paint data.
-         * @param presentTime The time at which the frame will be presented.
-         */
-        void prePaintScreen(KWin::ScreenPrePaintData &data, std::chrono::milliseconds presentTime) override;
-
-        /**
          * @brief Prepares a window for painting.
          * @param w The effect window.
          * @param data The window pre-paint data.

--- a/src/Shader.cpp
+++ b/src/Shader.cpp
@@ -27,7 +27,8 @@ namespace ShapeCorners
     }
 } // namespace ShapeCorners
 
-ShapeCorners::Shader::Shader() {
+ShapeCorners::Shader::Shader()
+{
 
     qInfo() << "ShapeCorners: loading shaders...";
 
@@ -35,7 +36,8 @@ ShapeCorners::Shader::Shader() {
     const QString shaderFilePath = QStandardPaths::locate(QStandardPaths::GenericDataLocation,
                                                           QStringLiteral("kwin/shaders/shapecorners.frag"));
     // Generate the shader from file using the ShaderManager
-    m_shader = KWin::ShaderManager::instance()->generateShaderFromFile(KWin::ShaderTrait::MapTexture, QString(), shaderFilePath);
+    m_shader = KWin::ShaderManager::instance()->generateShaderFromFile(KWin::ShaderTrait::MapTexture, QString(),
+                                                                       shaderFilePath);
     if (!m_shader->isValid()) {
         qCritical() << "ShapeCorners: no valid shaders found! effect will not work.";
         return;
@@ -72,7 +74,7 @@ void ShapeCorners::Shader::Bind(const Window &window, const double scale) const
     const auto frameOffset = QVector2D(frameGeometry.topLeft() - expandedGeometry.topLeft());
     // Clamp the shadow size to the maximum allowed
     const qreal max_shadow_size = frameOffset.length();
-    const auto  shadowSize      = std::min(window.currentConfig->shadowSize * scale, max_shadow_size);
+    const auto  shadowSize      = std::min(window.currentConfig.shadowSize * scale, max_shadow_size);
     // Push the shader to the rendering stack
     KWin::ShaderManager::instance()->pushShader(m_shader.get());
     // Set all required uniforms
@@ -81,15 +83,15 @@ void ShapeCorners::Shader::Bind(const Window &window, const double scale) const
     m_shader->setUniform(m_shader_windowTopLeft, frameOffset);
     m_shader->setUniform(m_shader_usesNativeShadows, static_cast<int>(Config::useNativeDecorationShadows()));
     m_shader->setUniform(m_shader_front, 0);
-    m_shader->setUniform(m_shader_radius, static_cast<float>(window.currentConfig->cornerRadius * scale));
-    m_shader->setUniform(m_shader_outlineThickness, static_cast<float>(window.currentConfig->outlineSize * scale));
+    m_shader->setUniform(m_shader_radius, static_cast<float>(window.currentConfig.cornerRadius * scale));
+    m_shader->setUniform(m_shader_outlineThickness, static_cast<float>(window.currentConfig.outlineSize * scale));
     m_shader->setUniform(m_shader_secondOutlineThickness,
-                         static_cast<float>(window.currentConfig->secondOutlineSize * scale));
+                         static_cast<float>(window.currentConfig.secondOutlineSize * scale));
     m_shader->setUniform(m_shader_shadowSize, static_cast<float>(shadowSize));
-    m_shader->setUniform(m_shader_shadowColor, window.currentConfig->shadowColor.toQColor());
+    m_shader->setUniform(m_shader_shadowColor, window.currentConfig.shadowColor.toQColor());
     if (window.hasOutline()) {
-        m_shader->setUniform(m_shader_outlineColor, window.currentConfig->outlineColor.toQColor());
-        m_shader->setUniform(m_shader_secondOutlineColor, window.currentConfig->secondOutlineColor.toQColor());
+        m_shader->setUniform(m_shader_outlineColor, window.currentConfig.outlineColor.toQColor());
+        m_shader->setUniform(m_shader_secondOutlineColor, window.currentConfig.secondOutlineColor.toQColor());
     } else {
         m_shader->setUniform(m_shader_outlineColor, 0);
         m_shader->setUniform(m_shader_secondOutlineColor, 0);

--- a/src/TileChecker.cpp
+++ b/src/TileChecker.cpp
@@ -2,6 +2,7 @@
 #include "TileChecker.h"
 #include <ranges>
 #include "Window.h"
+#include "WindowManager.h"
 #if QT_VERSION_MAJOR >= 6
 #include <effect/effecthandler.h>
 #include <utility>
@@ -33,8 +34,7 @@ bool ShapeCorners::TileChecker::checkTiled_Recursive(double window_start, const 
     }
 
     bool found_last_chain = false;
-    for (auto &[kwindow, window]: m_managed) {
-
+    for (auto &[kwindow, window]: WindowManager::instance()->getWindows()) {
         // Skip windows without an effect
         if (!window->hasEffect()) {
             continue;
@@ -70,10 +70,10 @@ bool ShapeCorners::TileChecker::checkTiled_Recursive(double window_start, const 
     return found_last_chain;
 }
 
-void ShapeCorners::TileChecker::clearTiles() const
+void ShapeCorners::TileChecker::clearTiles()
 {
     // Iterate over all managed windows and reset their isTiled flag
-    for (const auto &window: m_managed | std::views::values) {
+    for (const auto window: WindowManager::instance()->getWindows() | std::views::values) {
         window->isTiled = false;
     }
 }

--- a/src/TileChecker.h
+++ b/src/TileChecker.h
@@ -8,10 +8,10 @@
 
 #pragma once
 
-#include <WindowManager.h>
 #include <cstdint>
 
 class QRect;
+
 namespace KWin
 {
     class EffectWindow;
@@ -30,18 +30,16 @@ namespace ShapeCorners
      */
     class TileChecker
     {
-
     public:
         /**
          * @brief Constructs a TileChecker with a reference to the managed window list.
-         * @param windowList Reference to the managed window list.
          */
-        explicit TileChecker(WindowList &windowList) : m_managed(windowList) {}
+        explicit TileChecker() = default;
 
         /**
          * @brief Clears the tiled state for all managed windows.
          */
-        void clearTiles() const;
+        static void clearTiles();
 
         /**
          * @brief Checks and marks tiled windows based on the given screen geometry.
@@ -50,11 +48,6 @@ namespace ShapeCorners
         void checkTiles(const QRect &screen);
 
     private:
-        /**
-         * @brief Reference to the managed window list.
-         */
-        WindowList &m_managed;
-
         /**
          * @brief End coordinate of the screen (x or y, depending on orientation).
          */

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -9,8 +9,8 @@
 #include <kwineffects.h>
 #endif
 
-ShapeCorners::Window::Window(KWin::EffectWindow *kwindow, const WindowConfig *config) :
-    w(kwindow), currentConfig(config)
+ShapeCorners::Window::Window(KWin::EffectWindow *kwindow) :
+    w(kwindow), lastAnimationDuration(Config::animationDuration()), currentConfig(WindowConfig::inactiveWindowConfig())
 {
     connect(Config::self(), &Config::configChanged, this, &Window::configChanged);
     configChanged();
@@ -28,7 +28,7 @@ bool ShapeCorners::Window::hasEffect() const
 
 bool ShapeCorners::Window::hasRoundCorners() const
 {
-    if (currentConfig->cornerRadius <= 0) {
+    if (currentConfig.cornerRadius <= 0) {
         return false;
     }
     if (w->isFullScreen()) {

--- a/src/Window.h
+++ b/src/Window.h
@@ -11,6 +11,8 @@
 #include <QObject>
 #include <QString>
 #include <chrono>
+
+#include "WindowConfig.h"
 #ifdef QT_DEBUG
 #include <QDebug>
 #endif
@@ -60,20 +62,29 @@ namespace ShapeCorners
          */
         bool isMaximized = false;
 
+        /// Duration remaining for the current animation, in milliseconds.
+        long lastAnimationDuration;
+
+        /// Whether an animation is currently running.
+        bool isAnimating = true;
+
+        /// Timestamp of the last active window change.
+        std::chrono::system_clock::time_point lastActiveChangedTime;
+
         /**
          * @brief Current window configuration that may be animated.
          */
-        const WindowConfig *currentConfig;
+        WindowConfig currentConfig;
 
         /**
          * @brief Constructs a Window object for the given EffectWindow.
          * @param kwindow Reference to the KWin EffectWindow.
-         * @param config Reference to the initial WindowConfig of the Window.
          */
-        explicit Window(KWin::EffectWindow *kwindow, const WindowConfig *config);
+        explicit Window(KWin::EffectWindow *kwindow);
 
         // don't allow copying
-        Window(const Window &)            = delete;
+        Window(const Window &) = delete;
+
         Window &operator=(const Window &) = delete;
 
         /**

--- a/src/WindowManager.h
+++ b/src/WindowManager.h
@@ -48,19 +48,24 @@ namespace ShapeCorners
         /**
          * @brief Constructs the WindowManager, registers D-Bus, and adds existing windows.
          */
-        explicit WindowManager(const WindowConfig *config);
+        explicit WindowManager();
+
+        /**
+         * Singleton instance access method.
+         * @return instance of WindowManager.
+         */
+        static const WindowManager *instance();
 
         /**
          * @brief Finds a managed window by its EffectWindow pointer.
          * @param kwindow The EffectWindow to search for.
          * @return Pointer to the managed Window, or nullptr if not found.
          */
-        Window *findWindow(const KWin::EffectWindow *kwindow);
+        Window *findWindow(const KWin::EffectWindow *kwindow) const;
 
         /**
          * @brief Checks and adds a window to management, or as a menu bar if it's a dock.
          * @param kwindow The EffectWindow to add.
-         * @param config The initial config of the window.
          *
          * @return True if a new managed window was added, false if:
          *
@@ -72,10 +77,15 @@ namespace ShapeCorners
          *
          * - The window is already managed (duplicate)
          */
-        bool addWindow(KWin::EffectWindow *kwindow, const WindowConfig *config);
+        bool addWindow(KWin::EffectWindow *kwindow);
+
+        /**
+         * @brief Returns the const list of managed windows.
+         * @return Const reference to the map of managed windows.
+         */
+        const WindowList &getWindows() const { return m_managed; }
 
     public Q_SLOTS:
-
         /**
          * @brief Returns a JSON string of all managed window titles and classes.
          * It is being used by the D-Bus interface.
@@ -85,7 +95,6 @@ namespace ShapeCorners
         QString get_window_titles() const;
 
     private Q_SLOTS:
-
         /**
          * @brief Handles removal of a window or menu bar.
          * @param kwindow The EffectWindow to remove.
@@ -124,7 +133,7 @@ namespace ShapeCorners
         /**
          * @brief Checks and marks tiled windows using TileChecker for all screens.
          */
-        void checkTiled();
+        void checkTiled() const;
 
         /**
          * @brief Checks and marks maximized for all windows.


### PR DESCRIPTION
Some facts were not addressed in #400 mentioned in #407

- Some windows don't get involved with the animation: Those windows that were not active and remained inactive during the active window change.
- When switching the active window from window A to window B and then to window C, while window A is still in the middle of the animation, it should continue without being interrupted.

This leads to reverting the logic from unified animation variables to window-specific variables and having a copy of the WindowConfig in each Window. This sounds like a full revert, but it still has the whole animation logic in the Animation class, and it still utilizes a time-based animation duration.