### PR TITLE
Fix X11 loop when reloading configurations

### DIFF
--- a/src/Animation.cpp
+++ b/src/Animation.cpp
@@ -71,7 +71,7 @@ void ShapeCorners::Animation::setActiveWindowChanged(Window *window)
 {
 #ifdef QT_DEBUG
     if (window) {
-        qDebug() << "ShapeCorners: Window activated" << window;
+        qDebug() << "ShapeCorners: Window activated" << *window;
     } else {
         qDebug() << "ShapeCorners: No window activated";
     }

--- a/src/Effect.h
+++ b/src/Effect.h
@@ -21,6 +21,7 @@
 
 #include <QObject>
 #include "Shader.h"
+#include <chrono>
 #if QT_VERSION_MAJOR >= 6
 #include <effect/offscreeneffect.h>
 #else
@@ -148,11 +149,15 @@ namespace ShapeCorners
         void windowAdded(KWin::EffectWindow *kwindow);
 
     private:
+        /// Timestamp of the last config reload.
+        std::chrono::system_clock::time_point lastConfigReloadTime = std::chrono::system_clock::time_point::min();
         /// Manages the shader used for rounded corners.
         Shader m_shaderManager;
         /// Manages the windows affected by the effect.
         std::unique_ptr<WindowManager> m_windowManager;
         /// Manages the animation state for window corner effects.
         std::unique_ptr<Animation> m_animation;
+
+        void WriteBreezeConfigOutlineIntensity(const QString &value);
     };
 } // namespace ShapeCorners

--- a/src/Shader.cpp
+++ b/src/Shader.cpp
@@ -32,9 +32,14 @@ ShapeCorners::Shader::Shader()
 
     qInfo() << "ShapeCorners: loading shaders...";
 
+#ifdef KWIN_X11
+    const QString shaderFileRelativePath = QStringLiteral("kwin-x11/shaders/shapecorners.frag");
+#else
+    const QString shaderFileRelativePath = QStringLiteral("kwin/shaders/shapecorners.frag");
+#endif
+
     // Locate the shader file in the standard data locations
-    const QString shaderFilePath = QStandardPaths::locate(QStandardPaths::GenericDataLocation,
-                                                          QStringLiteral("kwin/shaders/shapecorners.frag"));
+    const QString shaderFilePath = QStandardPaths::locate(QStandardPaths::GenericDataLocation, shaderFileRelativePath);
     // Generate the shader from file using the ShaderManager
     m_shader = KWin::ShaderManager::instance()->generateShaderFromFile(KWin::ShaderTrait::MapTexture, QString(),
                                                                        shaderFilePath);


### PR DESCRIPTION
Unfortunately, it seems that X11 reloads the entire KWin when reloading configurations, unlike Wayland.

Therefore, when I edit the configurations at startup, the KWin resets, and I revert the configuration inside the destructor function.

This creates an infinite loop, which causes the screen to keep flashing.

This issue began with #401 and was later reported in #409.