### PR TITLE
Replace QRegion with KWin::Region for KWinEffect API 6.6

### DIFF
--- a/src/Effect.cpp
+++ b/src/Effect.cpp
@@ -151,7 +151,11 @@ void ShapeCorners::Effect::prePaintWindow(
 #endif
 
         // Create a region for each rounded corner.
+#if KWIN_EFFECT_API_VERSION >= 237
+        KWin::Region reg{};
+#else
         QRegion reg{};
+#endif
         reg += QRect(geo.x(), geo.y(), size, size);
         reg += QRect(geo.x() + geo.width() - size, geo.y(), size, size);
         reg += QRect(geo.x(), geo.y() + geo.height() - size, size, size);
@@ -186,7 +190,12 @@ bool ShapeCorners::Effect::supported()
 
 #if QT_VERSION_MAJOR >= 6
 void ShapeCorners::Effect::drawWindow(const KWin::RenderTarget &renderTarget, const KWin::RenderViewport &viewport,
-                                      KWin::EffectWindow *kwindow, int mask, const QRegion &region,
+                                      KWin::EffectWindow *kwindow, int mask,
+#if KWIN_EFFECT_API_VERSION >= 237
+                                      const KWin::Region &region,
+#else
+                                      const QRegion &region,
+#endif
                                       KWin::WindowPaintData &data)
 {
 #else

--- a/src/Effect.h
+++ b/src/Effect.h
@@ -91,7 +91,13 @@ namespace ShapeCorners
          * @param data The window paint data.
          */
         void drawWindow(const KWin::RenderTarget &RenderTarget, const KWin::RenderViewport &viewport,
-                        KWin::EffectWindow *w, int mask, const QRegion &region, KWin::WindowPaintData &data) override;
+                        KWin::EffectWindow *w, int mask,
+#if KWIN_EFFECT_API_VERSION >= 237
+                        const KWin::Region &region,
+#else
+                        const QRegion &region,
+#endif
+                        KWin::WindowPaintData &data) override;
 #else
         /**
          * @brief Draws the window with the effect applied (Qt5 version).


### PR DESCRIPTION
I noticed the `QRegion` is replaced with `KWin::Region` in the most recent KWinEffect API in Neon Unstable.

This PR adds compatibility while keeping support for older versions.