### PR TITLE
Fix plugin crash caused by static QWidget initialization

### DIFF
--- a/src/WindowConfig.cpp
+++ b/src/WindowConfig.cpp
@@ -1,5 +1,6 @@
 #include "WindowConfig.h"
-#include <QWidget>
+#include <QGuiApplication>
+#include <QPalette>
 #include "Config.h"
 
 namespace
@@ -32,19 +33,20 @@ namespace
         constexpr float ROUNDING_FACTOR = 100.0F; // Factor for rounding to two decimal places
         return std::round(value * ROUNDING_FACTOR) / ROUNDING_FACTOR;
     }
-} // namespace
 
-namespace ShapeCorners
-{
     /**
-     * \brief Used only for its `palette()` function which holds the currently active highlight colors.
+     * @brief Returns the application palette for color lookups.
+     * @return The current application palette.
      */
-    const static QWidget m_widget{};
-} // namespace ShapeCorners
+    QPalette getApplicationPalette()
+    {
+        return QGuiApplication::palette();
+    }
+} // namespace
 
 ShapeCorners::WindowConfig ShapeCorners::WindowConfig::activeWindowConfig()
 {
-    const QPalette &m_palette = m_widget.palette();
+    const QPalette m_palette = getApplicationPalette();
     WindowConfig    config    = {
                   .cornerRadius      = static_cast<float>(Config::size()),
                   .shadowSize        = static_cast<float>(Config::shadowSize()),
@@ -81,7 +83,7 @@ ShapeCorners::WindowConfig ShapeCorners::WindowConfig::activeWindowConfig()
 
 ShapeCorners::WindowConfig ShapeCorners::WindowConfig::inactiveWindowConfig()
 {
-    const QPalette &m_palette = m_widget.palette();
+    const QPalette m_palette = getApplicationPalette();
     WindowConfig    config    = {
                   .cornerRadius      = static_cast<float>(Config::inactiveCornerRadius()),
                   .shadowSize        = static_cast<float>(Config::inactiveShadowSize()),


### PR DESCRIPTION
## Summary

- Fix plugin failing to load on KDE Plasma 6 / Qt6 / Wayland
- The static `QWidget m_widget` was being initialized before `QApplication` exists, causing Qt to abort
- Replace with `QGuiApplication::palette()` which doesn't require a widget instance

## Problem

The plugin crashes during load with this stack trace:
```
#3  libQt6Core.so.6
#4  _ZNK14QMessageLogger5fatalEPKcz (libQt6Core.so.6)
#5  libQt6Widgets.so.6
#6  _ZN7QWidgetC2EPS_6QFlagsIN2Qt10WindowTypeEE (libQt6Widgets.so.6)
#7  _GLOBAL__sub_I_WindowConfig.cpp (kwin4_effect_shapecorners.so)
```

Qt requires `QApplication` to exist before any `QWidget` can be created. The static initialization of `QWidget m_widget{}` on line 42 violates this requirement.

## Test plan

- [x] Verified plugin now loads successfully with `qdbus6 org.kde.KWin /Effects org.kde.kwin.Effects.loadEffect kwin4_effect_shapecorners`
- [x] Tested on KDE Plasma 6.5.5, Qt 6.10, KWin Wayland

🤖 Generated with [Claude Code](https://claude.com/claude-code)