### PR TITLE
Add Launchpad PPA uploads for Ubuntu-based workflows

### DIFF
--- a/.github/workflows/kubuntu2204-backports.yml
+++ b/.github/workflows/kubuntu2204-backports.yml
@@ -76,3 +76,13 @@ jobs:
         fingerprint: ${{ secrets.SOURCEFORGE_HOST_FINGERPRINT }}
         source: ${{ env.DEB_FILE }}
         target: /home/frs/project/kde-rounded-corners/nightly/kubuntu2204/${{ env.DEB_NAME }}_${{ github.job }}.deb
+
+    - name: Upload to Launchpad PPA
+      if: github.ref == 'refs/heads/master'
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.LAUNCHPAD_GPG_PRIVATE_KEY }}
+        GPG_KEY_ID: DCCACDF0AE2E535CEF20ABC1916523094AD3BA70
+      run: |
+        sudo apt-get install -y debhelper dput devscripts
+        echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+        sh tools/upload-to-launchpad.sh "$DEB_FILE" kwin-effect-roundcorners kubuntu2204 jammy

--- a/.github/workflows/kubuntu2404.yml
+++ b/.github/workflows/kubuntu2404.yml
@@ -79,7 +79,7 @@ jobs:
         compression-level: 0
         if-no-files-found: error
 
-    - name: Upload Release Asset
+    - name: Upload to SourceForge
       if: github.ref == 'refs/heads/master'
       uses: nicklasfrahm/scp-action@main
       with:
@@ -90,6 +90,16 @@ jobs:
         fingerprint: ${{ secrets.SOURCEFORGE_HOST_FINGERPRINT }}
         source: ${{ env.DEB_FILE }}
         target: /home/frs/project/kde-rounded-corners/nightly/kubuntu/${{ env.DEB_NAME }}_${{ github.job }}.deb
+
+    - name: Upload to Launchpad PPA
+      if: github.ref == 'refs/heads/master'
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.LAUNCHPAD_GPG_PRIVATE_KEY }}
+        GPG_KEY_ID: DCCACDF0AE2E535CEF20ABC1916523094AD3BA70
+      run: |
+        sudo apt-get install -y debhelper dput devscripts
+        echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+        sh tools/upload-to-launchpad.sh "$DEB_FILE" kwin-effect-roundcorners kubuntu2404 noble
 
 #     - name: Test
 #       working-directory: ${{github.workspace}}/build

--- a/.github/workflows/kubuntu2604.yml
+++ b/.github/workflows/kubuntu2604.yml
@@ -46,7 +46,7 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        apt-get install -y --no-install-recommends cmake g++ gettext extra-cmake-modules qt6-base-private-dev qt6-base-dev-tools libkf6configwidgets-dev libkf6kcmutils-dev kwin-dev libdrm-dev
+        apt-get install -y --no-install-recommends cmake g++ gettext extra-cmake-modules qt6-base-private-dev qt6-base-dev-tools libkf6configwidgets-dev libkf6kcmutils-dev kwin-dev kwin-x11-dev libdrm-dev
         apt-get install -y --no-install-recommends dpkg-dev file
 
     - name: Initialize CodeQL
@@ -55,37 +55,43 @@ jobs:
         languages: c-cpp
         build-mode: manual
 
-    - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake . -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
-
-    - name: Build
-      # Build your program with the given configuration
-      run: cmake --build . --config ${{env.BUILD_TYPE}} -j
+    - name: Configure & Build Wayland
+      run: |
+        cmake . -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+        cmake --build . --config ${{env.BUILD_TYPE}} -j
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4
       with:
         category: "/language:c-cpp"
 
-    - name: Package
+    - name: Package Wayland
       run: |
         cpack -V -G DEB
-        DEB_FILE=artifacts/${DEB_NAME}_${GITHUB_JOB}.deb
-        mkdir artifacts
-        mv ${DEB_NAME}.deb ${DEB_FILE}
-        echo "DEB_FILE=${DEB_FILE}" >> $GITHUB_ENV
+        mkdir -p artifacts
+        mv ${DEB_NAME}.deb artifacts/${DEB_NAME}_${GITHUB_JOB}.deb
+        echo "DEB_FILE_WAYLAND=artifacts/${DEB_NAME}_${GITHUB_JOB}.deb" >> $GITHUB_ENV
 
-    - name: Upload Workflow Artifact
+    - name: Configure & Build X11
+      run: |
+        cmake . -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DKWIN_X11=ON
+        cmake --build . --config ${{env.BUILD_TYPE}} -j
+
+    - name: Package X11
+      run: |
+        cpack -V -G DEB
+        mv ${DEB_NAME}_x11.deb artifacts/${DEB_NAME}_${GITHUB_JOB}_x11.deb
+        echo "DEB_FILE_X11=artifacts/${DEB_NAME}_${GITHUB_JOB}_x11.deb" >> $GITHUB_ENV
+
+    - name: Upload Workflow Artifacts
       uses: actions/upload-artifact@v6
       with:
         name: ${{ env.DEB_NAME }}
-        path: ${{ env.DEB_FILE }}
+        path: artifacts/
         compression-level: 0
         if-no-files-found: error
 
-    - name: Upload Release Asset
+    - name: Upload to SourceForge
       if: github.ref == 'refs/heads/master'
       uses: nicklasfrahm/scp-action@main
       with:
@@ -94,5 +100,16 @@ jobs:
         username: ${{ secrets.SOURCEFORGE_USERNAME }}
         key: ${{ secrets.SOURCEFORGE_KEY }}
         fingerprint: ${{ secrets.SOURCEFORGE_HOST_FINGERPRINT }}
-        source: ${{ env.DEB_FILE }}
-        target: /home/frs/project/kde-rounded-corners/nightly/${{ github.job }}/${{ env.DEB_NAME }}_${{ github.job }}.deb
+        source: "artifacts/*"
+        target: /home/frs/project/kde-rounded-corners/nightly/${{ github.job }}/
+
+    - name: Upload to Launchpad PPA
+      if: github.ref == 'refs/heads/master'
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.LAUNCHPAD_GPG_PRIVATE_KEY }}
+        GPG_KEY_ID: DCCACDF0AE2E535CEF20ABC1916523094AD3BA70
+      run: |
+        apt-get install -y debhelper dput devscripts
+        echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+        sh tools/upload-to-launchpad.sh "$DEB_FILE_WAYLAND" kwin-effect-roundcorners kubuntu2604 plucky
+        sh tools/upload-to-launchpad.sh "$DEB_FILE_X11" kwin-effect-roundcorners-x11 kubuntu2604 plucky

--- a/.github/workflows/neon.yml
+++ b/.github/workflows/neon.yml
@@ -52,37 +52,43 @@ jobs:
         build-mode: manual
 
     
-    - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake . -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
-
-    - name: Build
-      # Build your program with the given configuration
-      run: cmake --build . --config ${{env.BUILD_TYPE}} -j
+    - name: Configure & Build Wayland
+      run: |
+        cmake . -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+        cmake --build . --config ${{env.BUILD_TYPE}} -j
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4
       with:
         category: "/language:c-cpp"
 
-    - name: Package
+    - name: Package Wayland
       run: |
         cpack -V -G DEB
-        DEB_FILE=artifacts/${DEB_NAME}_${GITHUB_JOB}.deb
-        mkdir artifacts
-        mv ${DEB_NAME}.deb ${DEB_FILE}
-        echo "DEB_FILE=${DEB_FILE}" >> $GITHUB_ENV
+        mkdir -p artifacts
+        mv ${DEB_NAME}.deb artifacts/${DEB_NAME}_${GITHUB_JOB}.deb
+        echo "DEB_FILE_WAYLAND=artifacts/${DEB_NAME}_${GITHUB_JOB}.deb" >> $GITHUB_ENV
 
-    - name: Upload Workflow Artifact
+    - name: Configure & Build X11
+      run: |
+        cmake . -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DKWIN_X11=ON
+        cmake --build . --config ${{env.BUILD_TYPE}} -j
+
+    - name: Package X11
+      run: |
+        cpack -V -G DEB
+        mv ${DEB_NAME}_x11.deb artifacts/${DEB_NAME}_${GITHUB_JOB}_x11.deb
+        echo "DEB_FILE_X11=artifacts/${DEB_NAME}_${GITHUB_JOB}_x11.deb" >> $GITHUB_ENV
+
+    - name: Upload Workflow Artifacts
       uses: actions/upload-artifact@v6
       with:
         name: ${{ env.DEB_NAME }}
-        path: ${{ env.DEB_FILE }}
+        path: artifacts/
         compression-level: 0
         if-no-files-found: error
 
-    - name: Upload Release Asset
+    - name: Upload to SourceForge
       if: github.ref == 'refs/heads/master'
       uses: nicklasfrahm/scp-action@main
       with:
@@ -91,8 +97,19 @@ jobs:
         username: ${{ secrets.SOURCEFORGE_USERNAME }}
         key: ${{ secrets.SOURCEFORGE_KEY }}
         fingerprint: ${{ secrets.SOURCEFORGE_HOST_FINGERPRINT }}
-        source: ${{ env.DEB_FILE }}
-        target: /home/frs/project/kde-rounded-corners/nightly/neon/${{ env.DEB_NAME }}_${{ github.job }}.deb
+        source: "artifacts/*"
+        target: /home/frs/project/kde-rounded-corners/nightly/neon/
+
+    - name: Upload to Launchpad PPA
+      if: github.ref == 'refs/heads/master'
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.LAUNCHPAD_GPG_PRIVATE_KEY }}
+        GPG_KEY_ID: DCCACDF0AE2E535CEF20ABC1916523094AD3BA70
+      run: |
+        sudo apt-get install -y debhelper dput devscripts
+        echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+        sh tools/upload-to-launchpad.sh "$DEB_FILE_WAYLAND" kwin-effect-roundcorners-neon neon noble
+        sh tools/upload-to-launchpad.sh "$DEB_FILE_X11" kwin-effect-roundcorners-x11-neon neon noble
 
 #     - name: Test
 #       working-directory: ${{github.workspace}}/build

--- a/tools/upload-to-launchpad.sh
+++ b/tools/upload-to-launchpad.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Upload pre-built .deb to Launchpad PPA
+# Usage: ./upload-to-launchpad.sh <deb_file> <package_name> <distro_codename> <ubuntu_series>
+# Example: ./upload-to-launchpad.sh shapecorners.deb kwin4-effect-shapecorners-neon neon noble
+
+set -e
+
+DEB_FILE="$1"
+PACKAGE_NAME="$2"
+DISTRO_CODENAME="$3"
+UBUNTU_SERIES="$4"
+PPA="ppa:matinlotfali/kde-rounded-corners"
+
+if [ -z "$DEB_FILE" ] || [ -z "$PACKAGE_NAME" ] || [ -z "$DISTRO_CODENAME" ] || [ -z "$UBUNTU_SERIES" ]; then
+    echo "Usage: $0 <deb_file> <package_name> <distro_codename> <ubuntu_series>"
+    exit 1
+fi
+
+# Extract version from the .deb file
+DEB_VERSION=$(dpkg-deb -f "$DEB_FILE" Version)
+VERSION="${DEB_VERSION}~${DISTRO_CODENAME}1"
+
+echo "Creating source package for $PACKAGE_NAME version $VERSION..."
+
+# Create working directory
+WORK_DIR=$(mktemp -d)
+SRC_DIR="$WORK_DIR/${PACKAGE_NAME}-${VERSION}"
+mkdir -p "$SRC_DIR/debian"
+
+# Copy the pre-built .deb
+cp "$DEB_FILE" "$SRC_DIR/"
+DEB_BASENAME=$(basename "$DEB_FILE")
+
+# Create minimal debian/ files
+cat > "$SRC_DIR/debian/control" <<EOF
+Source: ${PACKAGE_NAME}
+Section: kde
+Priority: optional
+Maintainer: Matin Lotfaliei <matinlotfali@gmail.com>
+Build-Depends: debhelper-compat (= 13)
+Standards-Version: 4.6.0
+
+Package: ${PACKAGE_NAME}
+Architecture: amd64
+Depends: \${misc:Depends}
+Description: KDE Rounded Corners effect
+ This KWin effect rounds the corners of your windows and adds
+ an outline around them.
+ .
+ This package is for ${DISTRO_CODENAME}.
+EOF
+
+cat > "$SRC_DIR/debian/rules" <<EOF
+#!/usr/bin/make -f
+%:
+	dh \$@
+
+override_dh_auto_build:
+	# Pre-built binary, nothing to build
+
+override_dh_auto_install:
+	dpkg-deb -x ${DEB_BASENAME} debian/${PACKAGE_NAME}
+EOF
+chmod +x "$SRC_DIR/debian/rules"
+
+echo "13" > "$SRC_DIR/debian/compat"
+
+cat > "$SRC_DIR/debian/changelog" <<EOF
+${PACKAGE_NAME} (${VERSION}) ${UBUNTU_SERIES}; urgency=medium
+
+  * Pre-built package for ${DISTRO_CODENAME}
+
+ -- Matin Lotfaliei <matinlotfali@gmail.com>  $(date -R)
+EOF
+
+mkdir -p "$SRC_DIR/debian/source"
+echo "3.0 (native)" > "$SRC_DIR/debian/source/format"
+
+# Build source package
+cd "$SRC_DIR"
+dpkg-buildpackage -S -sa -us -uc
+
+# Sign the source package
+cd "$WORK_DIR"
+debsign -k"${GPG_KEY_ID}" "${PACKAGE_NAME}_${VERSION}_source.changes"
+
+# Upload to Launchpad
+dput "$PPA" "${PACKAGE_NAME}_${VERSION}_source.changes"
+
+echo "Upload complete!"
+rm -rf "$WORK_DIR"


### PR DESCRIPTION
## Summary
- Add `tools/upload-to-launchpad.sh` script to create source packages from pre-built .deb files
- Upload packages to `ppa:matinlotfali/kde-rounded-corners`
- Plasma 6.4+ distros (neon, kubuntu2604) build both Wayland and X11 packages

## Package names
| Distro | Package(s) |
|--------|-----------|
| Kubuntu 22.04 | `kwin-effect-roundcorners` |
| Kubuntu 24.04 | `kwin-effect-roundcorners` |
| Kubuntu 26.04 | `kwin-effect-roundcorners`, `kwin-effect-roundcorners-x11` |
| KDE Neon | `kwin-effect-roundcorners-neon`, `kwin-effect-roundcorners-x11-neon` |

## User install command
```bash
sudo add-apt-repository ppa:matinlotfali/kde-rounded-corners
sudo apt install kwin-effect-roundcorners  # or kwin-effect-roundcorners-neon for Neon
```

## Required GitHub secret
- `LAUNCHPAD_GPG_PRIVATE_KEY` - GPG private key for signing packages

## Test plan
- [x] Add `LAUNCHPAD_GPG_PRIVATE_KEY` secret
- [ ] Verify neon workflow uploads both packages
- [ ] Verify kubuntu2604 workflow uploads both packages
- [ ] Verify kubuntu2404/2204 workflows upload single package
- [ ] Test installation from PPA

🤖 Generated with [Claude Code](https://claude.com/claude-code)