### PR TITLE
Fix semi-transparent black pixels at rounded corners

### DIFF
--- a/src/shaders/shapecorners_shadows.glsl
+++ b/src/shaders/shapecorners_shadows.glsl
@@ -126,7 +126,7 @@ vec4 getNativeShadow(vec2 coord0, float r, vec4 default_tex)
 vec4 getShadow(vec2 coord0, float r, vec4 default_tex)
 {
     if (!isDrawingShadows()) {
-        return vec4(0.0, 0.0, 0.0, 0.0);
+        return vec4(default_tex.rgb, 0.0);
     } else if (usesNativeShadows) {
         return getNativeShadow(coord0, r, default_tex);
     } else {


### PR DESCRIPTION
## Summary
- When shadows are disabled, `getShadow()` returned `vec4(0,0,0,0)` (transparent **black**)
- During anti-aliasing at corner edges, mixing the window color with transparent black darkened the RGB, producing visible black fringe pixels when composited onto the desktop
- Fix: preserve the window pixel's RGB in the transparent return value so anti-aliasing only fades the alpha without shifting color

Closes #430