### PR TITLE
Remove CodeQL from CI/CD workflows

### DIFF
--- a/.github/workflows/kubuntu2404.yml
+++ b/.github/workflows/kubuntu2404.yml
@@ -24,13 +24,6 @@ jobs:
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ubuntu-24.04
 
-    permissions:
-      # required for all workflows
-      security-events: write
-
-      # required to fetch internal or private CodeQL packs
-      packages: read
-
     steps:
     - name: Check out repository
       uses: actions/checkout@v6
@@ -45,12 +38,6 @@ jobs:
         sudo apt-get -y install --no-install-recommends cmake g++ gettext extra-cmake-modules qttools5-dev libkf5configwidgets-dev kwin-dev
         sudo apt-get -y install --no-install-recommends dpkg-dev file
 
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
-      with:
-        languages: c-cpp
-        build-mode: manual
-    
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
@@ -59,11 +46,6 @@ jobs:
     - name: Build
       # Build your program with the given configuration
       run: cmake --build . --config ${{env.BUILD_TYPE}} -j
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
-      with:
-        category: "/language:c-cpp"
 
     - name: Package
       run: |

--- a/.github/workflows/kubuntu2604.yml
+++ b/.github/workflows/kubuntu2604.yml
@@ -27,13 +27,6 @@ jobs:
       image: ubuntu:26.04
       options: --user root
 
-    permissions:
-      # required for all workflows
-      security-events: write
-
-      # required to fetch internal or private CodeQL packs
-      packages: read
-
     steps:
     - name: Refresh Ubuntu Packages
       # automatically use a local mirror when fetching from the network
@@ -53,21 +46,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
-      with:
-        languages: c-cpp
-        build-mode: manual
-
     - name: Configure & Build Wayland
       run: |
         cmake . -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
         cmake --build . --config ${{env.BUILD_TYPE}} -j
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
-      with:
-        category: "/language:c-cpp"
 
     - name: Package Wayland
       run: |

--- a/.github/workflows/neon.yml
+++ b/.github/workflows/neon.yml
@@ -26,13 +26,6 @@ jobs:
     container:
       image: invent-registry.kde.org/neon/docker-images/plasma:user
       options: --user root
-    permissions:
-      # required for all workflows
-      security-events: write
-
-      # required to fetch internal or private CodeQL packs
-      packages: read
-
     steps:
     - name: Refresh Ubuntu Packages
       run: |
@@ -50,22 +43,10 @@ jobs:
       with:
         fetch-depth: 0
         
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
-      with:
-        languages: c-cpp
-        build-mode: manual
-
-    
     - name: Configure & Build Wayland
       run: |
         cmake . -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
         cmake --build . --config ${{env.BUILD_TYPE}} -j
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
-      with:
-        category: "/language:c-cpp"
 
     - name: Package Wayland
       run: |


### PR DESCRIPTION
- CodeQL was running on three workflows (`kubuntu2404`, `kubuntu2604`, `neon`) duplicating the same `c-cpp` analysis on every push and nightly.
- Findings were rare on this small rendering plugin; the bug classes CodeQL is strongest at (user-input parsing, network, crypto) are largely absent here.
- `clang-tidy` (via `.clangd`) already covers local static analysis for the same codebase.
- Drops the `Initialize CodeQL` and `Perform CodeQL Analysis` steps and the `permissions:` block they required (`security-events: write`, `packages: read`).