### PR TITLE
Fix rough corners on CSD XWayland windows after #492

### DIFF
--- a/src/shaders/shapecorners_shadows.glsl
+++ b/src/shaders/shapecorners_shadows.glsl
@@ -126,7 +126,13 @@ vec4 getNativeShadow(vec2 coord0, float r, vec4 default_tex)
 vec4 getShadow(vec2 coord0, float r, vec4 default_tex)
 {
     if (!isDrawingShadows()) {
-        return vec4(default_tex.rgb * default_tex.a, 0.0);
+        if (hasExpandedSize()) {
+            // Preserve RGB so anti-aliasing only fades alpha (fix for #430)
+            return vec4(default_tex.rgb, 0.0);
+        }
+        // Windows without a shadow buffer (e.g. CSD XWayland apps like Steam)
+        // need premultiplied-valid output or the compositor brightens edge pixels (#491)
+        return vec4(0.0, 0.0, 0.0, 0.0);
     } else if (usesNativeShadows) {
         return getNativeShadow(coord0, r, default_tex);
     } else {

--- a/src/shaders/shapecorners_shadows.glsl
+++ b/src/shaders/shapecorners_shadows.glsl
@@ -126,7 +126,7 @@ vec4 getNativeShadow(vec2 coord0, float r, vec4 default_tex)
 vec4 getShadow(vec2 coord0, float r, vec4 default_tex)
 {
     if (!isDrawingShadows()) {
-        return vec4(default_tex.rgb, 0.0);
+        return vec4(default_tex.rgb * default_tex.a, 0.0);
     } else if (usesNativeShadows) {
         return getNativeShadow(coord0, r, default_tex);
     } else {


### PR DESCRIPTION
Fixes regression reported in #491 where Steam (CSD XWayland) shows rough/aliased rounded corners since the #492 fix for #430

Root cause: for windows without a shadow buffer (`hasExpandedSize == false`), the fallback return of `vec4(default_tex.rgb, 0.0)` violates the premultiplied-alpha invariant (RGB > A), so the compositor's blend over the desktop brightens edge pixels

Multiplying by `default_tex.a` restores the invariant and still preserves the #430 fix (transparent regions produce `(0,0,0,0)`, opaque regions keep RGB * 1)