### PR TITLE
Improve discoverability of download links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This effect is maintained on KDE Plasma desktop versions 5.27 to 6.6+ in various
 
 ![before-after](https://github.com/user-attachments/assets/cbd98412-ee47-4f4b-8b80-297328dfb1f5)
 
-### Tested on
+## Tested configurations + Download links (.deb, .rpm)
 * ![Wayland](https://img.shields.io/badge/Wayland-supported-green?logo=wayland) ![Wayland](https://img.shields.io/badge/X11-supported-green?logo=X.org)
 - ![Kubuntu 22.04 Jammy](https://img.shields.io/badge/-not_supported-red?label=Kubuntu%2022.04&logo=kubuntu&branch=master)
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;


### PR DESCRIPTION
Opening this PR because I personally had a hard time figuring out the presence of Download links in the "Tested on" section.
(I looked everywhere for an "official" way to install for Kubuntu, and couldn't find it until I stumbled across [this issue](https://github.com/matinlotfali/KDE-Rounded-Corners/issues/493#issuecomment-4261559416))
There might be better ways to make these links even more visible, but I figured this is a good start.

Also I'm taking this opportunity to thank you for this repo, it works like a charm and I especially enjoy how easy it is to play with the settings. Kudos! :pray: 