### PR TITLE
Fix kwin-x11 6.6.90 build on Fedora Rawhide and Neon Unstable

### DIFF
--- a/.github/workflows/neon-unstable.yml
+++ b/.github/workflows/neon-unstable.yml
@@ -38,14 +38,20 @@ jobs:
         sudo apt-get install -y --no-install-recommends cmake g++ gettext extra-cmake-modules qt6-base-dev-tools libkf6configwidgets-dev libkf6kcmutils-dev kwin-dev kwin-x11-dev
         sudo apt-get install -y --no-install-recommends dpkg-dev file
     
-    - name: Configure CMake
+    - name: Configure CMake (Wayland)
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
-    - name: Build
+    - name: Build (Wayland)
       # Build your program with the given configuration
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} -j
+
+    - name: Configure CMake (X11)
+      run: cmake -B ${{github.workspace}}/build-x11 -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DKWIN_X11=ON
+
+    - name: Build (X11)
+      run: cmake --build ${{github.workspace}}/build-x11 --config ${{env.BUILD_TYPE}} -j
 
 #     - name: Test
 #       working-directory: ${{github.workspace}}/build

--- a/src/Effect.cpp
+++ b/src/Effect.cpp
@@ -121,29 +121,33 @@ void ShapeCorners::Effect::reconfigure(const ReconfigureFlags flags)
     }
 }
 
+#if KWIN_EFFECT_API_VERSION >= 237
 #if KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 6, 80)
 void ShapeCorners::Effect::prePaintWindow(KWin::RenderView *view, KWin::EffectWindow *kwindow,
                                           KWin::WindowPrePaintData &data)
-#elif KWIN_EFFECT_API_VERSION >= 237
+#else
 void ShapeCorners::Effect::prePaintWindow(KWin::RenderView *view, KWin::EffectWindow *kwindow,
                                           KWin::WindowPrePaintData &data, std::chrono::milliseconds time)
+#endif // KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 6, 80)
 #else
 void ShapeCorners::Effect::prePaintWindow(KWin::EffectWindow *kwindow, KWin::WindowPrePaintData &data,
                                           std::chrono::milliseconds time)
-#endif
+#endif // KWIN_EFFECT_API_VERSION >= 237
 {
     // Find the managed window structure.
     auto *window = m_windowManager->findWindow(kwindow);
 
     // If the shader is not valid or the window is not managed or doesn't need the effect, fall back to default.
     if (!m_shaderManager.IsValid() || window == nullptr || !window->hasEffect()) {
+#if KWIN_EFFECT_API_VERSION >= 237
 #if KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 6, 80)
         OffscreenEffect::prePaintWindow(view, kwindow, data);
-#elif KWIN_EFFECT_API_VERSION >= 237
+#else
         OffscreenEffect::prePaintWindow(view, kwindow, data, time);
+#endif // KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 6, 80)
 #else
         OffscreenEffect::prePaintWindow(kwindow, data, time);
-#endif
+#endif // KWIN_EFFECT_API_VERSION >= 237
         return;
     }
 
@@ -165,14 +169,14 @@ void ShapeCorners::Effect::prePaintWindow(KWin::EffectWindow *kwindow, KWin::Win
         // Calculate geometry and corner size for Qt5.
         const auto geo  = (kwindow->frameGeometry() * KWin::effects->renderTargetScale()).toRect();
         const auto size = (int) (window->currentConfig.cornerRadius * KWin::effects->renderTargetScale());
-#endif
+#endif // QT_VERSION_MAJOR >= 6
 
         // Create a region for each rounded corner.
 #if KWIN_EFFECT_API_VERSION >= 237
         KWin::Region reg{};
 #else
         QRegion reg{};
-#endif
+#endif // KWIN_EFFECT_API_VERSION >= 237
         reg += QRect(geo.x(), geo.y(), size, size);
         reg += QRect(geo.x() + geo.width() - size, geo.y(), size, size);
         reg += QRect(geo.x(), geo.y() + geo.height() - size, size, size);
@@ -185,7 +189,7 @@ void ShapeCorners::Effect::prePaintWindow(KWin::EffectWindow *kwindow, KWin::Win
 #else
         data.opaque -= reg;
         data.paint += reg;
-#endif
+#endif // KWIN_EFFECT_API_VERSION >= 237
 #endif // KWIN_PLUGIN_VERSION_NUM < QT_VERSION_CHECK(6, 6, 80)
 
         // Mark the window as having translucent regions.

--- a/src/Effect.cpp
+++ b/src/Effect.cpp
@@ -197,13 +197,15 @@ void ShapeCorners::Effect::prePaintWindow(KWin::EffectWindow *kwindow, KWin::Win
     }
 
     // Call the base implementation.
+#if KWIN_EFFECT_API_VERSION >= 237
 #if KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 6, 80)
     OffscreenEffect::prePaintWindow(view, kwindow, data);
-#elif KWIN_EFFECT_API_VERSION >= 237
+#else
     OffscreenEffect::prePaintWindow(view, kwindow, data, time);
+#endif // KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 6, 80)
 #else
     OffscreenEffect::prePaintWindow(kwindow, data, time);
-#endif
+#endif // KWIN_EFFECT_API_VERSION >= 237
 }
 
 bool ShapeCorners::Effect::supported()

--- a/src/Effect.h
+++ b/src/Effect.h
@@ -81,15 +81,17 @@ namespace ShapeCorners
          * @param data The window pre-paint data.
          * @param time The time since the last frame.
          */
+#if KWIN_EFFECT_API_VERSION >= 237
 #if KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 6, 80)
         void prePaintWindow(KWin::RenderView *view, KWin::EffectWindow *w, KWin::WindowPrePaintData &data) override;
-#elif KWIN_EFFECT_API_VERSION >= 237
+#else
         void prePaintWindow(KWin::RenderView *view, KWin::EffectWindow *w, KWin::WindowPrePaintData &data,
                             std::chrono::milliseconds time) override;
+#endif // KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 6, 80)
 #else
         void prePaintWindow(KWin::EffectWindow *w, KWin::WindowPrePaintData &data,
                             std::chrono::milliseconds time) override;
-#endif
+#endif // KWIN_EFFECT_API_VERSION >= 237
 
 #if QT_VERSION_MAJOR >= 6
         /**

--- a/src/TileChecker.cpp
+++ b/src/TileChecker.cpp
@@ -94,7 +94,8 @@ void ShapeCorners::TileChecker::checkTiles(const T &screen_rect)
     checkTiled_Recursive<true>(screen_rect.y(), 0);
 }
 
-#if KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 6, 80)
+// kwin-x11 keeps a high plugin version but an old effect API without KWin::Rect, so gate on the API too.
+#if KWIN_EFFECT_API_VERSION >= 237 && KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 6, 80)
 template void ShapeCorners::TileChecker::checkTiles<KWin::Rect>(const KWin::Rect &);
 #else
 template void ShapeCorners::TileChecker::checkTiles<QRect>(const QRect &);

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -17,14 +17,15 @@
 
 namespace
 {
-auto screenRegion(const auto *screen)
-{
-#if KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 6, 80)
-    return KWin::Region(screen->geometry());
+    auto screenRegion(const auto *screen)
+    {
+// kwin-x11 keeps a high plugin version but an old effect API without KWin::Region, so gate on the API too.
+#if KWIN_EFFECT_API_VERSION >= 237 && KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 6, 80)
+        return KWin::Region(screen->geometry());
 #else
-    return QRegion(screen->geometry());
+        return QRegion(screen->geometry());
 #endif
-}
+    }
 } // namespace
 
 /**


### PR DESCRIPTION
- kwin-x11 6.6.90 (now shipping on both Fedora Rawhide and KDE Neon, up from 6.6.5) breaks the kwin-x11 build, while the Wayland build still passes.
- kwin-x11 reports plugin version 6.6.90 but ships effect API 236, which has no `RenderView`, `KWin::Region`, or `KWin::Rect`; gating only on `KWIN_PLUGIN_VERSION_NUM >= 6.6.80` made it pick the Wayland code path.
- Gate the new-API branches on `KWIN_EFFECT_API_VERSION >= 237` as well, so kwin-x11 falls back to the old `prePaintWindow` signature and `QRegion`/`QRect`. This single fix covers the build everywhere kwin-x11 6.6.90 lands.
- Fixes both `prePaintWindow` call sites in `Effect.cpp`, including the base-implementation call at the end of the function that still referenced the kwin-x11-absent `view` parameter.
- `prePaintWindow` blocks in `Effect.h`/`Effect.cpp` use a nested `#if` (API outer, plugin version inner) since they have three distinct signatures; `WindowManager.cpp` and `TileChecker.cpp` use a single combined condition.
- Add an X11 build to the KDE Neon Unstable workflow so kwin-x11 build breaks are caught there too (the stable workflow already builds and packages X11).
- Verified the Wayland path (API 237) still builds; kwin-x11 path confirmed via preprocessor selection and the Neon Unstable X11 job.