### PR TITLE
Add Squircles

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ This effect is maintained on KDE Plasma desktop versions 5.27 to 6.6+ in various
 - Cleanups for the plugin logic, remove unneeded dependencies from CMakeLists.txt file - by [alex1701c](https://github.com/alex1701c)
 - Separate outline color for active and inactive windows - by [OrkenWhite](https://github.com/OrkenWhite)
 - Support for language translations - by [VictorR2007](https://github.com/VictorR2007) (See [How to add more translations?](#how-to-add-more-languages-to-the-translation))
+- Squircle corner shape - by [zxsleebu](https://github.com/zxsleebu) (See [#503](https://github.com/matinlotfali/KDE-Rounded-Corners/pull/503))
 
 <a href="https://github.com/matinlotfali/KDE-Rounded-Corners/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=matinlotfali/KDE-Rounded-Corners" />

--- a/src/Shader.cpp
+++ b/src/Shader.cpp
@@ -2,6 +2,7 @@
 #include "Shader.h"
 #include <QFile>
 #include <QStandardPaths>
+#include <cmath>
 #include "Config.h"
 #include "Utils.h"
 #include "Window.h"
@@ -24,6 +25,30 @@ namespace
     constexpr QVector2D toVector2D(const QSizeF &size)
     {
         return {static_cast<float>(size.width()), static_cast<float>(size.height())};
+    }
+
+    float calculateMagicRatio(const float squircle_power, const float squircle_blend)
+    {
+        const float circle_dist   = std::sqrt(2.0F);
+        const float squircle_dist = std::pow(2.0F, 1.0F / squircle_power);
+        const float blended_dist  = circle_dist * (1.0F - squircle_blend) + squircle_dist * squircle_blend;
+        const float numerator     = 1.0F - (1.0F / circle_dist);
+        const float denominator   = 1.0F - (1.0F / blended_dist);
+
+        return numerator / denominator;
+    }
+
+    float cachedMagicRatio(const float squircle_blend)
+    {
+        static float cached_blend = -1.0F;
+        static float cached_ratio = 1.0F;
+
+        if (cached_blend != squircle_blend) {
+            cached_blend = squircle_blend;
+            cached_ratio = calculateMagicRatio(4.0F, squircle_blend);
+        }
+
+        return cached_ratio;
     }
 } // namespace
 
@@ -56,6 +81,9 @@ ShapeCorners::Shader::Shader()
     m_shader_shadowColor            = m_shader->uniformLocation("shadowColor");
     m_shader_shadowSize             = m_shader->uniformLocation("shadowSize");
     m_shader_radius                 = m_shader->uniformLocation("radius");
+    m_shader_useSquircleShape       = m_shader->uniformLocation("useSquircleShape");
+    m_shader_squircleBlend          = m_shader->uniformLocation("squircleBlend");
+    m_shader_squircleMagicRatio     = m_shader->uniformLocation("squircleMagicRatio");
     m_shader_outlineColor           = m_shader->uniformLocation("outlineColor");
     m_shader_outlineThickness       = m_shader->uniformLocation("outlineThickness");
     m_shader_secondOutlineColor     = m_shader->uniformLocation("secondOutlineColor");
@@ -96,6 +124,10 @@ void ShapeCorners::Shader::Bind(const Window &window, const double scale) const
     m_shader->setUniform(m_shader_windowExpandedSize, toVector2D(expandedGeometry.size()));
     m_shader->setUniform(m_shader_windowTopLeft, frameOffset);
     m_shader->setUniform(m_shader_usesNativeShadows, static_cast<int>(Config::useNativeDecorationShadows()));
+    m_shader->setUniform(m_shader_useSquircleShape, static_cast<int>(Config::useSquircleShape()));
+    const auto squircleBlend = static_cast<float>(Config::squircleness());
+    m_shader->setUniform(m_shader_squircleBlend, squircleBlend);
+    m_shader->setUniform(m_shader_squircleMagicRatio, cachedMagicRatio(squircleBlend));
     m_shader->setUniform(m_shader_front, 0);
     m_shader->setUniform(m_shader_outlineThickness, static_cast<float>(window.currentConfig.outlineSize * scale));
     m_shader->setUniform(m_shader_secondOutlineThickness,

--- a/src/Shader.cpp
+++ b/src/Shader.cpp
@@ -2,7 +2,6 @@
 #include "Shader.h"
 #include <QFile>
 #include <QStandardPaths>
-#include <cmath>
 #include "Config.h"
 #include "Utils.h"
 #include "Window.h"
@@ -25,30 +24,6 @@ namespace
     constexpr QVector2D toVector2D(const QSizeF &size)
     {
         return {static_cast<float>(size.width()), static_cast<float>(size.height())};
-    }
-
-    float calculateMagicRatio(const float squircle_power, const float squircle_blend)
-    {
-        const float circle_dist   = std::sqrt(2.0F);
-        const float squircle_dist = std::pow(2.0F, 1.0F / squircle_power);
-        const float blended_dist  = circle_dist * (1.0F - squircle_blend) + squircle_dist * squircle_blend;
-        const float numerator     = 1.0F - (1.0F / circle_dist);
-        const float denominator   = 1.0F - (1.0F / blended_dist);
-
-        return numerator / denominator;
-    }
-
-    float cachedMagicRatio(const float squircle_blend)
-    {
-        static float cached_blend = -1.0F;
-        static float cached_ratio = 1.0F;
-
-        if (cached_blend != squircle_blend) {
-            cached_blend = squircle_blend;
-            cached_ratio = calculateMagicRatio(4.0F, squircle_blend);
-        }
-
-        return cached_ratio;
     }
 } // namespace
 
@@ -83,7 +58,6 @@ ShapeCorners::Shader::Shader()
     m_shader_radius                 = m_shader->uniformLocation("radius");
     m_shader_useSquircleShape       = m_shader->uniformLocation("useSquircleShape");
     m_shader_squircleBlend          = m_shader->uniformLocation("squircleBlend");
-    m_shader_squircleMagicRatio     = m_shader->uniformLocation("squircleMagicRatio");
     m_shader_outlineColor           = m_shader->uniformLocation("outlineColor");
     m_shader_outlineThickness       = m_shader->uniformLocation("outlineThickness");
     m_shader_secondOutlineColor     = m_shader->uniformLocation("secondOutlineColor");
@@ -125,9 +99,7 @@ void ShapeCorners::Shader::Bind(const Window &window, const double scale) const
     m_shader->setUniform(m_shader_windowTopLeft, frameOffset);
     m_shader->setUniform(m_shader_usesNativeShadows, static_cast<int>(Config::useNativeDecorationShadows()));
     m_shader->setUniform(m_shader_useSquircleShape, static_cast<int>(Config::useSquircleShape()));
-    const auto squircleBlend = static_cast<float>(Config::squircleness());
-    m_shader->setUniform(m_shader_squircleBlend, squircleBlend);
-    m_shader->setUniform(m_shader_squircleMagicRatio, cachedMagicRatio(squircleBlend));
+    m_shader->setUniform(m_shader_squircleBlend, static_cast<float>(Config::squircleness()));
     m_shader->setUniform(m_shader_front, 0);
     m_shader->setUniform(m_shader_outlineThickness, static_cast<float>(window.currentConfig.outlineSize * scale));
     m_shader->setUniform(m_shader_secondOutlineThickness,

--- a/src/Shader.h
+++ b/src/Shader.h
@@ -96,6 +96,24 @@ namespace ShapeCorners
         int m_shader_radius = 0;
 
         /**
+         * \brief Reference to `uniform bool useSquircleShape;`
+         *        Whether corners should use a superellipse/squircle curve instead of a circular arc.
+         */
+        int m_shader_useSquircleShape = 0;
+
+        /**
+         * \brief Reference to `uniform float squircleBlend;`
+         *        Controls how strongly the corner distance blends from circular to squircle.
+         */
+        int m_shader_squircleBlend = 0;
+
+        /**
+         * \brief Reference to `uniform float squircleMagicRatio;`
+         *        Precomputed radius correction for the configured squircle blend.
+         */
+        int m_shader_squircleMagicRatio = 0;
+
+        /**
          * \brief Reference to `uniform bool usesNativeShadows;`
          *        Whether the window has custom shadows.
          */

--- a/src/Shader.h
+++ b/src/Shader.h
@@ -108,12 +108,6 @@ namespace ShapeCorners
         int m_shader_squircleBlend = 0;
 
         /**
-         * \brief Reference to `uniform float squircleMagicRatio;`
-         *        Precomputed radius correction for the configured squircle blend.
-         */
-        int m_shader_squircleMagicRatio = 0;
-
-        /**
          * \brief Reference to `uniform bool usesNativeShadows;`
          *        Whether the window has custom shadows.
          */

--- a/src/kcm/KCM.cpp
+++ b/src/kcm/KCM.cpp
@@ -88,6 +88,12 @@ ShapeCorners::KCM::KCM(QWidget *parent, const QVariantList &args) : KCModule(par
         ui->inactiveShadowGroupBox->setEnabled(useCustomShadows);
     });
 
+    // Enable/disable the squircleness control based on whether squircle corners are used
+    connect(ui->kcfg_UseSquircleShape, &QCheckBox::toggled, [=, this](bool useSquircle) {
+        ui->squirclenessLabel->setEnabled(useSquircle);
+        ui->kcfg_Squircleness->setEnabled(useSquircle);
+    });
+
     // It was expected that the Apply button would get enabled automatically as the gradient sliders move, but it
     // doesn't. Maybe it is a bug on the KCM side. Need to check and delete these lines later.
     connect(ui->kcfg_ActiveShadowAlpha, &KGradientSelector::sliderMoved, this, &KCM::markAsChanged);

--- a/src/kcm/KCM.ui
+++ b/src/kcm/KCM.ui
@@ -139,11 +139,45 @@
           </widget>
          </item>
         </layout>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="kcfg_DisableRoundTile">
-         <property name="text">
-          <string>Disable Roundness on Tile</string>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="kcfg_UseSquircleShape">
+          <property name="text">
+           <string>Use squircle corner shape</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QFormLayout" name="squirclenessFormLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="squirclenessLabel">
+            <property name="text">
+             <string>Squircleness</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QDoubleSpinBox" name="kcfg_Squircleness">
+            <property name="decimals">
+             <number>2</number>
+            </property>
+            <property name="maximum">
+             <double>1.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>0.050000000000000</double>
+            </property>
+            <property name="value">
+             <double>0.550000000000000</double>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="kcfg_DisableRoundTile">
+          <property name="text">
+           <string>Disable Roundness on Tile</string>
          </property>
          <property name="checked">
           <bool>true</bool>

--- a/src/kcm/options.kcfg
+++ b/src/kcm/options.kcfg
@@ -12,6 +12,14 @@
         <entry name="InactiveCornerRadius" type="UInt">
             <default>10</default>
         </entry>
+        <entry name="UseSquircleShape" type="Bool">
+            <default>false</default>
+        </entry>
+        <entry name="Squircleness" type="Double">
+            <default>0.55</default>
+            <min>0</min>
+            <max>1</max>
+        </entry>
         <entry name="AnimationDuration" type="UInt">
             <default>250</default>
             <min>0</min>

--- a/src/kcm/options.kcfg
+++ b/src/kcm/options.kcfg
@@ -7,10 +7,10 @@
 
     <group name="Round-Corners">
         <entry name="Size" type="UInt">
-            <default>10</default>
+            <default>20</default>
         </entry>
         <entry name="InactiveCornerRadius" type="UInt">
-            <default>10</default>
+            <default>20</default>
         </entry>
         <entry name="UseSquircleShape" type="Bool">
             <default>false</default>

--- a/src/shaders/CMakeLists.txt
+++ b/src/shaders/CMakeLists.txt
@@ -3,6 +3,7 @@ set(SOURCE_SHADER_CORE "shapecorners_qt${QT_MAJOR_VERSION}_core.frag")
 
 set(SED_VARIABLES_COMMAND sed -i -e "/#include \"variables.glsl\"/ { r ${CMAKE_SOURCE_DIR}/src/shaders/variables.glsl" -e "d" -e "}")
 set(SED_SHADOWS_COMMAND sed -i -e "/#include \"shapecorners_shadows.glsl\"/ { r ${CMAKE_SOURCE_DIR}/src/shaders/shapecorners_shadows.glsl" -e "d" -e "}")
+set(SED_SQUIRCLES_COMMAND sed -i -e "/#include \"squircles.glsl\"/ { r ${CMAKE_SOURCE_DIR}/src/shaders/squircles.glsl" -e "d" -e "}")
 set(SED_MERGE_GLSL_COMMAND sed -e "/#include \"shapecorners.glsl\"/ { r ${CMAKE_SOURCE_DIR}/src/shaders/shapecorners.glsl" -e "d" -e "}")
 
 add_custom_target(
@@ -13,6 +14,8 @@ add_custom_target(
     COMMAND ${SED_SHADOWS_COMMAND} "${CMAKE_CURRENT_BINARY_DIR}/shapecorners_core.frag"
     COMMAND ${SED_VARIABLES_COMMAND} "${CMAKE_CURRENT_BINARY_DIR}/shapecorners.frag"
     COMMAND ${SED_VARIABLES_COMMAND} "${CMAKE_CURRENT_BINARY_DIR}/shapecorners_core.frag"
+    COMMAND ${SED_SQUIRCLES_COMMAND} "${CMAKE_CURRENT_BINARY_DIR}/shapecorners.frag"
+    COMMAND ${SED_SQUIRCLES_COMMAND} "${CMAKE_CURRENT_BINARY_DIR}/shapecorners_core.frag"
     DEPENDS
         "${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_SHADER}"
         "${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_SHADER_CORE}"

--- a/src/shaders/shapecorners.glsl
+++ b/src/shaders/shapecorners.glsl
@@ -6,6 +6,33 @@ bool is_within(vec2 point, vec2 corner_a, vec2 corner_b)
     return is_within(point.x, corner_a.x, corner_b.x) && is_within(point.y, corner_a.y, corner_b.y);
 }
 
+float squircleDistance(vec2 delta)
+{
+    vec2 d = abs(delta);
+
+    const float squircle_power = 4.0;
+    float       circle         = length(d);
+    float       squircle       = pow(pow(d.x, squircle_power) + pow(d.y, squircle_power), 1.0 / squircle_power);
+
+    return mix(circle, squircle, squircleBlend);
+}
+
+float shape_distance(vec2 point, vec2 center, float radius)
+{
+    vec2 delta = point - center;
+    if (!useSquircleShape) {
+        return length(delta);
+    }
+
+    float       effective_radius = radius * squircleMagicRatio;
+    float       center_shift     = effective_radius - radius;
+    vec2        d                = abs(delta);
+    vec2        shifted_d        = d + center_shift;
+    float       dist             = squircleDistance(shifted_d);
+
+    return dist - effective_radius + radius;
+}
+
 /*
  *  \brief This function is used to choose the pixel color based on its distance to the center input.
  *  \param coord0: The XY point
@@ -24,7 +51,7 @@ vec4 shapeCorner(vec2 coord0, vec4 tex, vec2 start, float angle, vec4 coord_shad
     vec2  outlineStart         = start + outlineThickness * angle_vector * corner_length;
     vec2  secondOutlineStart   = start + (outlineThickness + secondOutlineThickness) * angle_vector * corner_length;
     vec2  outerOutlineEnd      = start - outerOutlineThickness * angle_vector * corner_length;
-    float distance_from_center = distance(coord0, roundness_center);
+    float distance_from_center = shape_distance(coord0, roundness_center, radius);
     bool  inOutlineZone =
             (hasPrimaryOutline() && outlineThickness >= radius && is_within(coord0, outlineStart, start)) ||
             (hasSecondOutline() && outlineThickness + secondOutlineThickness >= radius &&

--- a/src/shaders/shapecorners.glsl
+++ b/src/shaders/shapecorners.glsl
@@ -6,31 +6,27 @@ bool is_within(vec2 point, vec2 corner_a, vec2 corner_b)
     return is_within(point.x, corner_a.x, corner_b.x) && is_within(point.y, corner_a.y, corner_b.y);
 }
 
-float squircleDistance(vec2 delta)
-{
-    vec2 d = abs(delta);
-
-    const float squircle_power = 4.0;
-    float       circle         = length(d);
-    float       squircle       = pow(pow(d.x, squircle_power) + pow(d.y, squircle_power), 1.0 / squircle_power);
-
-    return mix(circle, squircle, squircleBlend);
-}
-
+/*
+ *  \brief Distance from a point to a corner center, as a circular arc or a squircle curve.
+ *  \param point: The XY point being shaded.
+ *  \param center: The XY center of the corner roundness.
+ *  \param radius: The corner radius in pixels.
+ *  \return A field whose value equals `radius` on the corner boundary.
+ */
 float shape_distance(vec2 point, vec2 center, float radius)
 {
-    vec2 delta = point - center;
     if (!useSquircleShape) {
-        return length(delta);
+        return distance(point, center);
     }
 
-    float       effective_radius = radius * squircleMagicRatio;
-    float       center_shift     = effective_radius - radius;
-    vec2        d                = abs(delta);
-    vec2        shifted_d        = d + center_shift;
-    float       dist             = squircleDistance(shifted_d);
+    // Pure circle/superellipse blend: on a straight edge the offset is axis-aligned, so this
+    // equals distance(point, center) and leaves the edge undistorted; only the corners curve.
+    float dist = squircle_distance(point, center);
 
-    return dist - effective_radius + radius;
+    // Renormalize to ~unit gradient so the outline and antialiasing bands keep a uniform
+    // width at the corners, where the raw superellipse gradient would otherwise dip below 1.
+    float grad = squircle_gradient(point, center);
+    return radius + (dist - radius) / max(grad, 1e-4);
 }
 
 /*

--- a/src/shaders/shapecorners_shadows.glsl
+++ b/src/shaders/shapecorners_shadows.glsl
@@ -1,3 +1,4 @@
+#include "squircles.glsl"
 #include "variables.glsl"
 
 uniform bool  usesNativeShadows;
@@ -20,10 +21,16 @@ float parametricBlend(float t)
  */
 vec4 getShadowByDistance(vec2 coord0, vec2 center)
 {
-    float distance_from_center = distance(coord0, center);
-    float percent              = 1.0 - distance_from_center / shadowSize;
-    percent                    = clamp(percent, 0.0, 1.0);
-    percent                    = parametricBlend(percent);
+    float distance_from_center;
+    if (useSquircleShape) {
+        distance_from_center = squircle_distance(coord0, center);
+    } else {
+        distance_from_center = distance(coord0, center);
+    }
+
+    float percent = 1.0 - distance_from_center / shadowSize;
+    percent       = clamp(percent, 0.0, 1.0);
+    percent       = parametricBlend(percent);
     if (percent < 0.0) {
         return vec4(0.0, 0.0, 0.0, 0.0);
     }

--- a/src/shaders/squircles.glsl
+++ b/src/shaders/squircles.glsl
@@ -1,0 +1,43 @@
+
+uniform bool  useSquircleShape; // Whether to use a superellipse/squircle curve for corners.
+uniform float squircleBlend;    // How strongly to blend circular corners toward a squircle.
+
+const float squirclePower = 4.0;
+
+/*
+ *  \brief Length of a vector under the corner metric: a plain circle, or a circle/superellipse
+ *         blend when squircles are enabled. Shared by the window edge (shape_distance) and the
+ *         shadow (getShadowByDistance) so both round their corners with the same shape.
+ *  \param point: The XY point being shaded.
+ *  \param center: The XY center of the corner roundness.
+ *  \return The blended length.
+ */
+float squircle_distance(vec2 point, vec2 center)
+{
+    vec2  delta    = point - center;
+    vec2  d        = abs(delta);
+    float circle   = length(d);
+    float squircle = pow(pow(d.x, squirclePower) + pow(d.y, squirclePower), 1.0 / squirclePower);
+
+    return mix(circle, squircle, squircleBlend);
+}
+
+/*
+ *  \brief Magnitude of the gradient of squircle_length. The superellipse blend is not a true
+ *         signed-distance field, so its gradient dips below 1 toward the diagonal; shape_distance
+ *         divides by this so the outline and antialiasing bands stay a uniform width all around.
+ *  \param point: The XY point being shaded.
+ *  \param center: The XY center of the corner roundness.
+ *  \return The gradient magnitude (1.0 for the plain-circle case).
+ */
+float squircle_gradient(vec2 point, vec2 center)
+{
+    vec2  delta              = point - center;
+    vec2  d                  = abs(delta);
+    float circle             = length(d);
+    float squircle           = pow(pow(d.x, squirclePower) + pow(d.y, squirclePower), 1.0 / squirclePower);
+    vec2  circle_gradient    = (circle > 0.0) ? d / circle : vec2(0.0);
+    vec2  squircle_gradient_ = (squircle > 0.0) ? pow(d / squircle, vec2(squirclePower - 1.0)) : vec2(0.0);
+
+    return length(mix(circle_gradient, squircle_gradient_, squircleBlend));
+}

--- a/src/shaders/variables.glsl
+++ b/src/shaders/variables.glsl
@@ -1,5 +1,8 @@
 uniform sampler2D sampler;            // The painted contents of the window.
 uniform float     radius;             // The thickness of the outline in pixels specified in settings.
+uniform bool      useSquircleShape;   // Whether to use a superellipse/squircle curve for corners.
+uniform float     squircleBlend;      // How strongly to blend circular corners toward a squircle.
+uniform float     squircleMagicRatio; // Precomputed radius correction for the current squircleBlend.
 uniform vec2      windowSize;         // Containing `window->frameGeometry().size()`
 uniform vec2      windowExpandedSize; // Containing `window->expandedGeometry().size()`
 

--- a/src/shaders/variables.glsl
+++ b/src/shaders/variables.glsl
@@ -1,8 +1,5 @@
 uniform sampler2D sampler;            // The painted contents of the window.
 uniform float     radius;             // The thickness of the outline in pixels specified in settings.
-uniform bool      useSquircleShape;   // Whether to use a superellipse/squircle curve for corners.
-uniform float     squircleBlend;      // How strongly to blend circular corners toward a squircle.
-uniform float     squircleMagicRatio; // Precomputed radius correction for the current squircleBlend.
 uniform vec2      windowSize;         // Containing `window->frameGeometry().size()`
 uniform vec2      windowExpandedSize; // Containing `window->expandedGeometry().size()`
 


### PR DESCRIPTION
- Adds an optional squircle corner shape, continuing the work from #497 by @zxsleebu
- Applies the squircle shape to shadows and renormalizes via an in-shader gradient

> Fully functional squircles.
> <img width="206" height="90" alt="image" src="https://github.com/user-attachments/assets/9b5ba9c8-b27e-4082-9bf5-051ced197eb7" />

Before: | After:
-|-
<img width="300" height="300" alt="image_2026-04-27_21-07-15" src="https://github.com/user-attachments/assets/d3826183-b44d-414b-91da-d2d075ea9ed9" /> | <img width="300" height="300" alt="image_2026-04-27_21-07-30" src="https://github.com/user-attachments/assets/10985daf-e0db-4e24-b2d7-00b4d7a5d4eb" />