### PR TITLE
Fix Neon CI: drop full-upgrade, use Azure mirror

### DIFF
--- a/.github/workflows/neon-unstable.yml
+++ b/.github/workflows/neon-unstable.yml
@@ -31,7 +31,9 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Refresh Ubuntu Packages
-      run: sudo apt-get update && sudo apt-get full-upgrade -y --allow-downgrades
+      run: |
+        sudo find /etc/apt -type f \( -name 'sources.list' -o -name '*.list' -o -name '*.sources' \) -exec sed -i 's|archive.ubuntu.com|azure.archive.ubuntu.com|g' {} +
+        sudo apt-get update
 
     - name: Install Dependencies
       run: |

--- a/.github/workflows/neon.yml
+++ b/.github/workflows/neon.yml
@@ -36,7 +36,6 @@ jobs:
       run: |
         sudo find /etc/apt -type f \( -name 'sources.list' -o -name '*.list' -o -name '*.sources' \) -exec sed -i 's|archive.ubuntu.com|azure.archive.ubuntu.com|g' {} +
         sudo apt-get update
-        sudo apt-get full-upgrade -y --allow-downgrades
 
     - name: Install Dependencies
       run: |


### PR DESCRIPTION
- Drops `apt-get full-upgrade` from both Neon workflows; a broken `ubuntu-advantage-tools` (Ubuntu Pro client) upgrade was failing the unstable job, and it is unrelated to building this effect
- Build dependencies (and any upgrades they require) are still pulled in the Install Dependencies step
- Switches the unstable workflow to the Azure Ubuntu mirror, matching the stable workflow