### PR TITLE
Set isMaximized by comparing with clientArea

### DIFF
--- a/src/TileChecker.cpp
+++ b/src/TileChecker.cpp
@@ -82,8 +82,7 @@ void ShapeCorners::TileChecker::clearTiles()
     }
 }
 
-template<typename T>
-void ShapeCorners::TileChecker::checkTiles(const T &screen_rect)
+void ShapeCorners::TileChecker::checkTiles(const QRectF &screen_rect)
 {
     // Check horizontally
     screen_end = screen_rect.x() + screen_rect.width();
@@ -93,10 +92,3 @@ void ShapeCorners::TileChecker::checkTiles(const T &screen_rect)
     screen_end = screen_rect.y() + screen_rect.height();
     checkTiled_Recursive<true>(screen_rect.y(), 0);
 }
-
-// kwin-x11 keeps a high plugin version but an old effect API without KWin::Rect, so gate on the API too.
-#if KWIN_EFFECT_API_VERSION >= 237 && KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 6, 80)
-template void ShapeCorners::TileChecker::checkTiles<KWin::Rect>(const KWin::Rect &);
-#else
-template void ShapeCorners::TileChecker::checkTiles<QRect>(const QRect &);
-#endif

--- a/src/TileChecker.h
+++ b/src/TileChecker.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <QRectF>
 #include <cstdint>
 
 namespace KWin
@@ -41,10 +42,9 @@ namespace ShapeCorners
 
         /**
          * @brief Checks and marks tiled windows based on the given screen geometry.
-         * @param screen The Rect representing the screen area to check.
+         * @param screen_rect The rectangle representing the screen area to check.
          */
-        template<typename T>
-        void checkTiles(const T &screen_rect);
+        void checkTiles(const QRectF &screen_rect);
 
     private:
         /**

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -15,19 +15,6 @@
 #include <kwineffects.h>
 #endif
 
-namespace
-{
-    auto screenRegion(const auto *screen)
-    {
-// kwin-x11 keeps a high plugin version but an old effect API without KWin::Region, so gate on the API too.
-#if KWIN_EFFECT_API_VERSION >= 237 && KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 6, 80)
-        return KWin::Region(screen->geometry());
-#else
-        return QRegion(screen->geometry());
-#endif
-    }
-} // namespace
-
 /**
  * @brief Pointer to the singleton instance of WindowManager.
  */
@@ -189,32 +176,9 @@ void ShapeCorners::WindowManager::checkTiled() const
     TileChecker tileChecker;
     // Check tiling for each screen, excluding menu bars
     for (const auto &screen: KWin::effects->screens()) {
-        const auto screen_region = getRegionWithoutMenus(screenRegion(screen));
-        const auto geometry      = screen_region.boundingRect();
+        const auto geometry = KWin::effects->clientArea(KWin::MaximizeArea, screen, KWin::effects->currentDesktop());
         tileChecker.checkTiles(geometry);
     }
-}
-
-template<typename T>
-T ShapeCorners::WindowManager::getRegionWithoutMenus(T screen_region) const
-{
-#ifdef DEBUG_MAXIMIZED
-    qDebug() << "ShapeCorners: screen region" << screen_region;
-#endif
-
-    // Subtract all menu bar geometries from the screen region
-    for (const auto &ptr: m_menuBars) {
-#ifdef DEBUG_MAXIMIZED
-        qDebug() << "ShapeCorners: menu is" << ptr->frameGeometry();
-#endif
-        screen_region -= ptr->frameGeometry().toRect();
-    }
-
-#ifdef DEBUG_MAXIMIZED
-    qDebug() << "ShapeCorners: screen region without menus" << screen_region;
-#endif
-
-    return screen_region;
 }
 
 void ShapeCorners::WindowManager::checkMaximized(KWin::EffectWindow *kwindow) const

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -176,7 +176,11 @@ void ShapeCorners::WindowManager::checkTiled() const
     TileChecker tileChecker;
     // Check tiling for each screen, excluding menu bars
     for (const auto &screen: KWin::effects->screens()) {
+#if KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 6, 90)
+        const auto geometry = KWin::effects->clientArea(KWin::MaximizeArea, screen);
+#else
         const auto geometry = KWin::effects->clientArea(KWin::MaximizeArea, screen, KWin::effects->currentDesktop());
+#endif
         tileChecker.checkTiles(geometry);
     }
 }

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -217,28 +217,22 @@ T ShapeCorners::WindowManager::getRegionWithoutMenus(T screen_region) const
     return screen_region;
 }
 
-void ShapeCorners::WindowManager::checkMaximized(KWin::EffectWindow *kwindow)
+void ShapeCorners::WindowManager::checkMaximized(KWin::EffectWindow *kwindow) const
 {
     auto *const window = findWindow(kwindow);
     if (window == nullptr) {
         return;
     }
 
-    window->isMaximized = false;
+    const auto maxArea  = KWin::effects->clientArea(KWin::MaximizeArea, kwindow);
+    window->isMaximized = (kwindow->frameGeometry() == maxArea);
 
-    const auto screen_region = getRegionWithoutMenus(screenRegion(kwindow->screen()));
-
-    // Check if the window fills the screen region
-    auto remaining = screen_region - kwindow->frameGeometry().toRect();
 #ifdef DEBUG_MAXIMIZED
-    qDebug() << "ShapeCorners: active window remaining region" << remaining;
-#endif
-    if (remaining.isEmpty()) {
-        window->isMaximized = true;
-#ifdef DEBUG_MAXIMIZED
+    qDebug() << "ShapeCorners: maximize area" << maxArea << "window" << kwindow->frameGeometry();
+    if (window->isMaximized) {
         qInfo() << "ShapeCorners: window maximized" << kwindow->windowClass();
-#endif
     }
+#endif
 }
 
 void ShapeCorners::WindowManager::windowResized(KWin::EffectWindow *kwindow, const QRectF &size)

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -176,11 +176,17 @@ void ShapeCorners::WindowManager::checkTiled() const
     TileChecker tileChecker;
     // Check tiling for each screen, excluding menu bars
     for (const auto &screen: KWin::effects->screens()) {
+
+#if KWIN_EFFECT_API_VERSION >= 237
 #if KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 6, 90)
         const auto geometry = KWin::effects->clientArea(KWin::MaximizeArea, screen);
 #else
         const auto geometry = KWin::effects->clientArea(KWin::MaximizeArea, screen, KWin::effects->currentDesktop());
-#endif
+#endif // KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 6, 90)
+#else
+        const auto geometry = KWin::effects->clientArea(KWin::MaximizeArea, screen, KWin::effects->currentDesktop());
+#endif // KWIN_EFFECT_API_VERSION >= 237
+
         tileChecker.checkTiles(geometry);
     }
 }

--- a/src/WindowManager.h
+++ b/src/WindowManager.h
@@ -106,7 +106,7 @@ namespace ShapeCorners
          * @brief Checks if a window is maximized by comparing its geometry to the screen region.
          * @param kwindow The EffectWindow to check.
          */
-        void checkMaximized(KWin::EffectWindow *kwindow);
+        void checkMaximized(KWin::EffectWindow *kwindow) const;
 
         /**
          * @brief Handles window resize events by updating tiling and maximized state.

--- a/src/WindowManager.h
+++ b/src/WindowManager.h
@@ -145,14 +145,5 @@ namespace ShapeCorners
          * @brief Checks and marks maximized for all windows.
          */
         void checkMaximized();
-
-        /**
-         * @brief Returns the region of the screen excluding menu bars.
-         * @param screen_geometry The region of the screen.
-         * @return Region without menu bars.
-         */
-        template<typename T>
-        [[nodiscard]]
-        T getRegionWithoutMenus(T screen_region) const;
     };
 } // namespace ShapeCorners


### PR DESCRIPTION
This PRP sets `isMaximized` by comparing the window's frame geometry to `KWin::effects->clientArea(KWin::MaximizeArea, kwindow)` instead of the dock-region subtraction. 

This should fix #507 