### PR TITLE
Use a tolerance when comparing geometry for maximized and tiled detection

### DIFF
--- a/src/TileChecker.cpp
+++ b/src/TileChecker.cpp
@@ -20,10 +20,15 @@ constexpr static uint8_t MAX_TILE_DEPTH = 5;
  */
 constexpr static uint8_t MAX_GAP_SIZE = 40;
 
+/**
+ * @brief Tolerance for comparing tile edge positions, in logical pixels.
+ */
+constexpr static double TILE_TOLERANCE = 1.0;
+
 template<bool vertical>
 bool ShapeCorners::TileChecker::checkTiled_Recursive(double window_start, const uint8_t depth)
 {
-    if (window_start == screen_end) {
+    if (qAbs(window_start - screen_end) <= TILE_TOLERANCE) {
         // Found the last chain of tiles.
         // A single window spanning the screen is not a tile, so require at least 2.
         return depth >= 2;
@@ -58,7 +63,7 @@ bool ShapeCorners::TileChecker::checkTiled_Recursive(double window_start, const 
         }
 
         // If the window starts at the expected position and has a positive size
-        if (orientation_x == window_start && orientation_width > 0) {
+        if (qAbs(orientation_x - window_start) <= TILE_TOLERANCE && orientation_width > 0) {
             // Recursively check the next tile in the chain
             if (checkTiled_Recursive<vertical>(window_start + orientation_width + gap, depth + 1)) {
                 window->isTiled  = true; // Mark every tile as you go back to the first.

--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -198,8 +198,14 @@ void ShapeCorners::WindowManager::checkMaximized(KWin::EffectWindow *kwindow) co
         return;
     }
 
-    const auto maxArea  = KWin::effects->clientArea(KWin::MaximizeArea, kwindow);
-    window->isMaximized = (kwindow->frameGeometry() == maxArea);
+    const auto frame   = kwindow->frameGeometry();
+    const auto maxArea = KWin::effects->clientArea(KWin::MaximizeArea, kwindow);
+
+    constexpr qreal tolerance = 1.0;
+    window->isMaximized = qAbs(frame.x() - maxArea.x()) <= tolerance
+                       && qAbs(frame.y() - maxArea.y()) <= tolerance
+                       && qAbs(frame.width() - maxArea.width()) <= tolerance
+                       && qAbs(frame.height() - maxArea.height()) <= tolerance;
 
 #ifdef DEBUG_MAXIMIZED
     qDebug() << "ShapeCorners: maximize area" << maxArea << "window" << kwindow->frameGeometry();


### PR DESCRIPTION
- Maximized detection compared `frameGeometry()` to the maximize area with an exact `QRectF ==`, which fails under fractional display scaling and for client-side-decorated windows (apps without a server-side titlebar), since the frame can land a sub-pixel off the computed area
- Tiled detection had the same problem with exact `double` comparisons of tile edge positions
- Both now compare each edge with a 1px tolerance
- Fixes #509, follow-up to #508