### PR TITLE
Load the core-profile shader on KWin 6.7+

### DIFF
--- a/src/Shader.cpp
+++ b/src/Shader.cpp
@@ -32,10 +32,18 @@ ShapeCorners::Shader::Shader()
 
     qInfo() << "ShapeCorners: loading shaders...";
 
-#ifdef KWIN_X11
-    const QString shaderFileRelativePath = QStringLiteral("kwin-x11/shaders/shapecorners.frag");
+    // KWin 6.7 ports effect shaders to the GLSL version of the live context and stops back-porting
+    // modern syntax onto the legacy variant, so the core-profile shader is required from 6.7 onwards.
+#if KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 7, 0)
+    const auto shaderFileName = QStringLiteral("shapecorners_core.frag");
 #else
-    const QString shaderFileRelativePath = QStringLiteral("kwin/shaders/shapecorners.frag");
+    const auto shaderFileName = QStringLiteral("shapecorners.frag");
+#endif
+
+#ifdef KWIN_X11
+    const QString shaderFileRelativePath = QStringLiteral("kwin-x11/shaders/") + shaderFileName;
+#else
+    const QString shaderFileRelativePath = QStringLiteral("kwin/shaders/") + shaderFileName;
 #endif
 
     // Locate the shader file in the standard data locations


### PR DESCRIPTION
Fixes #514 (and #512): `ShapeCorners: no valid shaders found` on Plasma 6 Wayland

This is done by selecting `shapecorners_core.frag` from 6.7 onwards and keeping the legacy shader for older KWin versions

## Here is why:
- KWin 6.7 (KDE/kwin@e618c04c9a) now ports effect shaders to the GLSL version of the live context and prepends `#version 140` instead of back-porting modern syntax onto the legacy shader
- Strict GLSL compilers (e.g. NVIDIA) then reject the legacy `varying`/`gl_FragColor`/`texture2D` variant, while lenient drivers (Mesa) still accept it, which is why it only failed for some users