### PR TITLE
Return bool from drawWindow on KWin 6.7.80+

### DIFF
--- a/src/Effect.cpp
+++ b/src/Effect.cpp
@@ -215,7 +215,12 @@ bool ShapeCorners::Effect::supported()
 }
 
 #if QT_VERSION_MAJOR >= 6
-void ShapeCorners::Effect::drawWindow(const KWin::RenderTarget &renderTarget, const KWin::RenderViewport &viewport,
+#if KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 7, 80)
+bool ShapeCorners::Effect::drawWindow(
+#else
+void ShapeCorners::Effect::drawWindow(
+#endif // KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 7, 80)
+                                      const KWin::RenderTarget &renderTarget, const KWin::RenderViewport &viewport,
                                       KWin::EffectWindow *kwindow, int mask,
 #if KWIN_EFFECT_API_VERSION >= 237
                                       const KWin::Region &region,
@@ -236,12 +241,15 @@ void ShapeCorners::Effect::drawWindow(KWin::EffectWindow *kwindow, int mask, con
     // drawing.
     if (!m_shaderManager.IsValid() || window == nullptr || !window->hasEffect()) {
         unredirect(kwindow);
-#if QT_VERSION_MAJOR >= 6
+#if KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 7, 80)
+        return OffscreenEffect::drawWindow(renderTarget, viewport, kwindow, mask, region, data);
+#elif QT_VERSION_MAJOR >= 6
         OffscreenEffect::drawWindow(renderTarget, viewport, kwindow, mask, region, data);
+        return;
 #else
         OffscreenEffect::drawWindow(kwindow, mask, region, data);
-#endif
         return;
+#endif
     }
 
 #if QT_VERSION_MAJOR >= 6
@@ -262,13 +270,18 @@ void ShapeCorners::Effect::drawWindow(KWin::EffectWindow *kwindow, int mask, con
     glActiveTexture(GL_TEXTURE0);
 
     // Call the base implementation to actually draw the window.
-#if QT_VERSION_MAJOR >= 6
+#if KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 7, 80)
+    const bool result = OffscreenEffect::drawWindow(renderTarget, viewport, kwindow, mask, region, data);
+#elif QT_VERSION_MAJOR >= 6
     OffscreenEffect::drawWindow(renderTarget, viewport, kwindow, mask, region, data);
 #else
     OffscreenEffect::drawWindow(kwindow, mask, region, data);
 #endif
     // Unbind the shader after drawing.
     m_shaderManager.Unbind();
+#if KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 7, 80)
+    return result;
+#endif
 }
 
 void ShapeCorners::Effect::windowAdded(KWin::EffectWindow *kwindow)

--- a/src/Effect.cpp
+++ b/src/Effect.cpp
@@ -215,11 +215,11 @@ bool ShapeCorners::Effect::supported()
 }
 
 #if QT_VERSION_MAJOR >= 6
-#if KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 7, 80)
+#if KWIN_EFFECT_API_VERSION >= 237 && KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 7, 80)
 bool ShapeCorners::Effect::drawWindow(
 #else
 void ShapeCorners::Effect::drawWindow(
-#endif // KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 7, 80)
+#endif // KWIN_EFFECT_API_VERSION >= 237 && KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 7, 80)
                                       const KWin::RenderTarget &renderTarget, const KWin::RenderViewport &viewport,
                                       KWin::EffectWindow *kwindow, int mask,
 #if KWIN_EFFECT_API_VERSION >= 237
@@ -241,7 +241,7 @@ void ShapeCorners::Effect::drawWindow(KWin::EffectWindow *kwindow, int mask, con
     // drawing.
     if (!m_shaderManager.IsValid() || window == nullptr || !window->hasEffect()) {
         unredirect(kwindow);
-#if KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 7, 80)
+#if KWIN_EFFECT_API_VERSION >= 237 && KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 7, 80)
         return OffscreenEffect::drawWindow(renderTarget, viewport, kwindow, mask, region, data);
 #elif QT_VERSION_MAJOR >= 6
         OffscreenEffect::drawWindow(renderTarget, viewport, kwindow, mask, region, data);
@@ -270,7 +270,7 @@ void ShapeCorners::Effect::drawWindow(KWin::EffectWindow *kwindow, int mask, con
     glActiveTexture(GL_TEXTURE0);
 
     // Call the base implementation to actually draw the window.
-#if KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 7, 80)
+#if KWIN_EFFECT_API_VERSION >= 237 && KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 7, 80)
     const bool result = OffscreenEffect::drawWindow(renderTarget, viewport, kwindow, mask, region, data);
 #elif QT_VERSION_MAJOR >= 6
     OffscreenEffect::drawWindow(renderTarget, viewport, kwindow, mask, region, data);
@@ -279,7 +279,7 @@ void ShapeCorners::Effect::drawWindow(KWin::EffectWindow *kwindow, int mask, con
 #endif
     // Unbind the shader after drawing.
     m_shaderManager.Unbind();
-#if KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 7, 80)
+#if KWIN_EFFECT_API_VERSION >= 237 && KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 7, 80)
     return result;
 #endif
 }

--- a/src/Effect.h
+++ b/src/Effect.h
@@ -103,7 +103,12 @@ namespace ShapeCorners
          * @param region The paint region.
          * @param data The window paint data.
          */
-        void drawWindow(const KWin::RenderTarget &RenderTarget, const KWin::RenderViewport &viewport,
+#if KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 7, 80)
+        bool drawWindow(
+#else
+        void drawWindow(
+#endif // KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 7, 80)
+                        const KWin::RenderTarget &RenderTarget, const KWin::RenderViewport &viewport,
                         KWin::EffectWindow *w, int mask,
 #if KWIN_EFFECT_API_VERSION >= 237
                         const KWin::Region &region,

--- a/src/Effect.h
+++ b/src/Effect.h
@@ -103,11 +103,11 @@ namespace ShapeCorners
          * @param region The paint region.
          * @param data The window paint data.
          */
-#if KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 7, 80)
+#if KWIN_EFFECT_API_VERSION >= 237 && KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 7, 80)
         bool drawWindow(
 #else
         void drawWindow(
-#endif // KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 7, 80)
+#endif // KWIN_EFFECT_API_VERSION >= 237 && KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 7, 80)
                         const KWin::RenderTarget &RenderTarget, const KWin::RenderViewport &viewport,
                         KWin::EffectWindow *w, int mask,
 #if KWIN_EFFECT_API_VERSION >= 237


### PR DESCRIPTION
Fixes the neon-unstable build failure: KWin commit [f25a765c0b](https://invent.kde.org/plasma/kwin/-/commit/f25a765c0b947cebdc1f3ac3e24865958a4da0a6) changed `Effect::drawWindow` to return `bool` (false means the GL context was lost, e.g. after a GPU reset) and marked it `[[nodiscard]]`.
- Gates the return type on `KWIN_PLUGIN_VERSION_NUM >= 6.7.80`, following the existing 6.6.80 gate for `prePaintWindow`.
- The early-exit path returns the base result directly; the main path captures it, unbinds the shader, then returns it. Older Qt6 and Qt5 paths are unchanged.