### PR TITLE
Add gradient outlines

### DIFF
--- a/ClassDiagram.md
+++ b/ClassDiagram.md
@@ -88,15 +88,27 @@ classDiagram
         class WindowConfig {
             cornerRadius: float
             shadowSize: float
-            outlineSize: float
-            secondOutlineSize: float
-            outerOutlineSize: float
             shadowColor: FloatColor
-            outlineColor: FloatColor
-            secondOutlineColor: FloatColor
-            outerOutlineColor: FloatColor
+            outline: OutlineConfig
+            secondOutline: OutlineConfig
+            outerOutline: OutlineConfig
             activeWindowConfig()
             inactiveWindowConfig()
+            operator+()
+            operator-()
+            operator*()
+            operator/()
+            operator!()
+            operator+=()
+            round()
+            clamp()
+        }
+
+        class OutlineConfig {
+            size: float
+            angle: float
+            color1: FloatColor
+            color2: FloatColor
             operator+()
             operator-()
             operator*()
@@ -192,7 +204,8 @@ classDiagram
     Window --> EffectWindow: Manages
     Window ..> WindowConfig: Uses
     Window ..> Config: Uses
-    WindowConfig o-- FloatColor: Contains
+    WindowConfig o-- OutlineConfig: Contains
+    OutlineConfig o-- FloatColor: Contains
     WindowConfig ..> Config: Uses
     WindowManager o-- Window: Contains
     QDBusConnection <.. WindowManager: Registers

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This effect is maintained on KDE Plasma desktop versions 5.27 to 6.6+ in various
   [![](https://img.shields.io/sourceforge/dm/kde-rounded-corners/nightly%2Fdebian13?label=Download%20%5Bkwin4_effect_shapecorners_debian13.deb%5D)](https://sourceforge.net/projects/kde-rounded-corners/files/nightly/debian13/kwin4_effect_shapecorners_debian13.deb/download)
 - [![Debian Sid](https://img.shields.io/github/actions/workflow/status/matinlotfali/KDE-Rounded-Corners/debian-sid.yml?branch=master&label=Debian%20Sid%20(Unstable)&logo=debian)](https://github.com/matinlotfali/KDE-Rounded-Corners/actions/workflows/debian-sid.yml)
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-  ![](https://img.shields.io/badge/Plasma-6.6-blue)
+  ![](https://img.shields.io/badge/Plasma-6.7-darkgreen)
 - [![openSUSE Leap 16](https://img.shields.io/github/actions/workflow/status/matinlotfali/KDE-Rounded-Corners/leap16.yml?branch=master&label=openSUSE%20Leap%2016&logo=opensuse&logoColor=white)](https://github.com/matinlotfali/KDE-Rounded-Corners/actions/workflows/leap16.yml)
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
   ![](https://img.shields.io/badge/Plasma-6.4-lightgreen)
@@ -85,12 +85,23 @@ This effect is maintained on KDE Plasma desktop versions 5.27 to 6.6+ in various
 - Separate outline color for active and inactive windows - by [OrkenWhite](https://github.com/OrkenWhite)
 - Support for language translations - by [VictorR2007](https://github.com/VictorR2007) (See [How to add more translations?](#how-to-add-more-languages-to-the-translation))
 - Squircle corner shape - by [zxsleebu](https://github.com/zxsleebu) (See [#503](https://github.com/matinlotfali/KDE-Rounded-Corners/pull/503))
+- Linear gradient outlines with two color stops and an adjustable angle (See [#522](https://github.com/matinlotfali/KDE-Rounded-Corners/issues/522))
 
 <a href="https://github.com/matinlotfali/KDE-Rounded-Corners/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=matinlotfali/KDE-Rounded-Corners" />
 </a>
 
 # How to install using unofficial repositories
+
+Launchpad PPA at [matinlotfali/kde-rounded-corners](https://launchpad.net/~matinlotfali/+archive/ubuntu/kde-rounded-corners) for Kubuntu, Ubuntu, and KDE Neon
+
+```bash
+sudo add-apt-repository ppa:matinlotfali/kde-rounded-corners
+sudo apt update
+sudo apt install kwin-effect-roundcorners
+```
+
+> For the X11 build, use `kwin-effect-roundcorners-x11`. On KDE Neon the packages carry a `-neon` suffix (`kwin-effect-roundcorners-neon`, `kwin-effect-roundcorners-x11-neon`).
 
 Copr package at [matinlotfali/KDE-Rounded-Corners](https://copr.fedorainfracloud.org/coprs/matinlotfali/KDE-Rounded-Corners)
 

--- a/src/Shader.cpp
+++ b/src/Shader.cpp
@@ -67,11 +67,17 @@ ShapeCorners::Shader::Shader()
     m_shader_radius                 = m_shader->uniformLocation("radius");
     m_shader_useSquircleShape       = m_shader->uniformLocation("useSquircleShape");
     m_shader_squircleBlend          = m_shader->uniformLocation("squircleBlend");
-    m_shader_outlineColor           = m_shader->uniformLocation("outlineColor");
+    m_shader_outlineColor1          = m_shader->uniformLocation("outlineColor1");
+    m_shader_outlineColor2          = m_shader->uniformLocation("outlineColor2");
+    m_shader_outlineAngle           = m_shader->uniformLocation("outlineAngle");
     m_shader_outlineThickness       = m_shader->uniformLocation("outlineThickness");
-    m_shader_secondOutlineColor     = m_shader->uniformLocation("secondOutlineColor");
+    m_shader_secondOutlineColor1    = m_shader->uniformLocation("secondOutlineColor1");
+    m_shader_secondOutlineColor2    = m_shader->uniformLocation("secondOutlineColor2");
+    m_shader_secondOutlineAngle     = m_shader->uniformLocation("secondOutlineAngle");
     m_shader_secondOutlineThickness = m_shader->uniformLocation("secondOutlineThickness");
-    m_shader_outerOutlineColor      = m_shader->uniformLocation("outerOutlineColor");
+    m_shader_outerOutlineColor1     = m_shader->uniformLocation("outerOutlineColor1");
+    m_shader_outerOutlineColor2     = m_shader->uniformLocation("outerOutlineColor2");
+    m_shader_outerOutlineAngle      = m_shader->uniformLocation("outerOutlineAngle");
     m_shader_outerOutlineThickness  = m_shader->uniformLocation("outerOutlineThickness");
     m_shader_front                  = m_shader->uniformLocation("front");
     qInfo() << "ShapeCorners: shaders loaded.";
@@ -110,11 +116,11 @@ void ShapeCorners::Shader::Bind(const Window &window, const double scale) const
     m_shader->setUniform(m_shader_useSquircleShape, static_cast<int>(Config::useSquircleShape()));
     m_shader->setUniform(m_shader_squircleBlend, static_cast<float>(Config::squircleness()));
     m_shader->setUniform(m_shader_front, 0);
-    m_shader->setUniform(m_shader_outlineThickness, static_cast<float>(window.currentConfig.outlineSize * scale));
+    m_shader->setUniform(m_shader_outlineThickness, static_cast<float>(window.currentConfig.outline.size * scale));
     m_shader->setUniform(m_shader_secondOutlineThickness,
-                         static_cast<float>(window.currentConfig.secondOutlineSize * scale));
+                         static_cast<float>(window.currentConfig.secondOutline.size * scale));
     m_shader->setUniform(m_shader_outerOutlineThickness,
-                         static_cast<float>(window.currentConfig.outerOutlineSize * scale));
+                         static_cast<float>(window.currentConfig.outerOutline.size * scale));
     m_shader->setUniform(m_shader_shadowSize, static_cast<float>(shadowSize));
     m_shader->setUniform(m_shader_shadowColor, window.currentConfig.shadowColor.toQColor());
 
@@ -125,13 +131,30 @@ void ShapeCorners::Shader::Bind(const Window &window, const double scale) const
         m_shader->setUniform(m_shader_radius, 0.F);
     }
     if (window.hasOutline()) {
-        m_shader->setUniform(m_shader_outlineColor, window.currentConfig.outlineColor.toQColor());
-        m_shader->setUniform(m_shader_secondOutlineColor, window.currentConfig.secondOutlineColor.toQColor());
-        m_shader->setUniform(m_shader_outerOutlineColor, window.currentConfig.outerOutlineColor.toQColor());
+        const auto &outline       = window.currentConfig.outline;
+        const auto &secondOutline = window.currentConfig.secondOutline;
+        const auto &outerOutline  = window.currentConfig.outerOutline;
+        // color1 == color2 gives a solid outline; they differ only when a gradient is configured.
+        m_shader->setUniform(m_shader_outlineColor1, outline.color1.toQColor());
+        m_shader->setUniform(m_shader_outlineColor2, outline.color2.toQColor());
+        m_shader->setUniform(m_shader_outlineAngle, outline.angle);
+        m_shader->setUniform(m_shader_secondOutlineColor1, secondOutline.color1.toQColor());
+        m_shader->setUniform(m_shader_secondOutlineColor2, secondOutline.color2.toQColor());
+        m_shader->setUniform(m_shader_secondOutlineAngle, secondOutline.angle);
+        m_shader->setUniform(m_shader_outerOutlineColor1, outerOutline.color1.toQColor());
+        m_shader->setUniform(m_shader_outerOutlineColor2, outerOutline.color2.toQColor());
+        m_shader->setUniform(m_shader_outerOutlineAngle, outerOutline.angle);
     } else {
-        m_shader->setUniform(m_shader_outlineColor, QColor(0, 0, 0, 0));
-        m_shader->setUniform(m_shader_secondOutlineColor, QColor(0, 0, 0, 0));
-        m_shader->setUniform(m_shader_outerOutlineColor, QColor(0, 0, 0, 0));
+        const QColor transparent(0, 0, 0, 0);
+        m_shader->setUniform(m_shader_outlineColor1, transparent);
+        m_shader->setUniform(m_shader_outlineColor2, transparent);
+        m_shader->setUniform(m_shader_outlineAngle, 0.0F);
+        m_shader->setUniform(m_shader_secondOutlineColor1, transparent);
+        m_shader->setUniform(m_shader_secondOutlineColor2, transparent);
+        m_shader->setUniform(m_shader_secondOutlineAngle, 0.0F);
+        m_shader->setUniform(m_shader_outerOutlineColor1, transparent);
+        m_shader->setUniform(m_shader_outerOutlineColor2, transparent);
+        m_shader->setUniform(m_shader_outerOutlineAngle, 0.0F);
     }
 }
 

--- a/src/Shader.h
+++ b/src/Shader.h
@@ -126,10 +126,18 @@ namespace ShapeCorners
         int m_shader_shadowSize = 0;
 
         /**
-         * \brief Reference to `uniform vec4 outlineColor;`
-         *        Containing the RGBA of the outline color specified in settings.
+         * \brief Reference to `uniform vec4 outlineColor1;` and `uniform vec4 outlineColor2;`
+         *        Containing the RGBA of the outline's two gradient stops specified in settings.
+         *        The two stops are equal when the outline is a solid color.
          */
-        int m_shader_outlineColor = 0;
+        int m_shader_outlineColor1 = 0;
+        int m_shader_outlineColor2 = 0;
+
+        /**
+         * \brief Reference to `uniform float outlineAngle;`
+         *        Containing the outline gradient angle in degrees.
+         */
+        int m_shader_outlineAngle = 0;
 
         /**
          * \brief Reference to `uniform float outlineThickness;`
@@ -138,10 +146,18 @@ namespace ShapeCorners
         int m_shader_outlineThickness = 0;
 
         /**
-         * \brief Reference to `uniform vec4 secondOutlineColor;`
-         *        Containing the RGBA of the outline color specified in settings.
+         * \brief Reference to `uniform vec4 secondOutlineColor1;` and `uniform vec4 secondOutlineColor2;`
+         *        Containing the RGBA of the second outline's two gradient stops specified in settings.
+         *        The two stops are equal when the second outline is a solid color.
          */
-        int m_shader_secondOutlineColor = 0;
+        int m_shader_secondOutlineColor1 = 0;
+        int m_shader_secondOutlineColor2 = 0;
+
+        /**
+         * \brief Reference to `uniform float secondOutlineAngle;`
+         *        Containing the second outline gradient angle in degrees.
+         */
+        int m_shader_secondOutlineAngle = 0;
 
         /**
          * \brief Reference to `uniform float secondOutlineThickness;`
@@ -150,10 +166,18 @@ namespace ShapeCorners
         int m_shader_secondOutlineThickness = 0;
 
         /**
-         * \brief Reference to `uniform vec4 outerOutlineColor;`
-         *        Containing the RGBA of the outline color specified in settings.
+         * \brief Reference to `uniform vec4 outerOutlineColor1;` and `uniform vec4 outerOutlineColor2;`
+         *        Containing the RGBA of the outer outline's two gradient stops specified in settings.
+         *        The two stops are equal when the outer outline is a solid color.
          */
-        int m_shader_outerOutlineColor = 0;
+        int m_shader_outerOutlineColor1 = 0;
+        int m_shader_outerOutlineColor2 = 0;
+
+        /**
+         * \brief Reference to `uniform float outerOutlineAngle;`
+         *        Containing the outer outline gradient angle in degrees.
+         */
+        int m_shader_outerOutlineAngle = 0;
 
         /**
          * \brief Reference to `uniform float outerOutlineThickness;`

--- a/src/WindowConfig.cpp
+++ b/src/WindowConfig.cpp
@@ -1,4 +1,5 @@
 #include "WindowConfig.h"
+#include <QPalette>
 #include <QWidget>
 #include "Config.h"
 
@@ -32,6 +33,48 @@ namespace
         constexpr float ROUNDING_FACTOR = 100.0F; // Factor for rounding to two decimal places
         return std::round(value * ROUNDING_FACTOR) / ROUNDING_FACTOR;
     }
+
+    /**
+     * @brief Resolves a color from settings: either a palette role or a custom color, with alpha applied.
+     * @param palette The palette holding the current highlight colors.
+     * @param group The palette color group (Active or Inactive).
+     * @param usePalette Whether to use the palette role instead of the custom color.
+     * @param paletteRole The palette color role index.
+     * @param customColor The custom color to use when not using the palette.
+     * @param alpha The alpha channel to apply [0, 255].
+     * @return The resolved FloatColor.
+     */
+    ShapeCorners::FloatColor resolveColor(const QPalette &palette, const QPalette::ColorGroup group,
+                                          const bool usePalette, const uint paletteRole, const QColor &customColor,
+                                          const int alpha)
+    {
+        ShapeCorners::FloatColor color =
+                usePalette
+                        ? ShapeCorners::FloatColor(palette.color(group, static_cast<QPalette::ColorRole>(paletteRole)))
+                        : ShapeCorners::FloatColor(customColor);
+        color.setAlpha(alpha);
+        return color;
+    }
+
+    /**
+     * @brief Applies the second gradient stop and angle to an outline, or leaves it solid.
+     * @param outline The outline to update. Its color1 must already be set.
+     * @param isGradient Whether the outline uses a gradient.
+     * @param color2 The custom second-stop color; its own alpha is used.
+     * @param angleDeg The gradient angle in degrees.
+     * @note When not a gradient, color2 mirrors color1 and the angle is zeroed, so the shader draws a solid color.
+     */
+    void applyGradient(ShapeCorners::OutlineConfig &outline, const bool isGradient, const QColor &color2,
+                       const int angleDeg)
+    {
+        if (isGradient) {
+            outline.color2 = ShapeCorners::FloatColor(color2);
+            outline.angle  = static_cast<float>(angleDeg);
+        } else {
+            outline.color2 = outline.color1;
+            outline.angle  = 0.0F;
+        }
+    }
 } // namespace
 
 namespace ShapeCorners
@@ -42,173 +85,201 @@ namespace ShapeCorners
     const static QWidget m_widget{};
 } // namespace ShapeCorners
 
+ShapeCorners::OutlineConfig ShapeCorners::OutlineConfig::operator+(const OutlineConfig &other) const
+{
+    return OutlineConfig{.size   = size + other.size,
+                         .angle  = angle + other.angle,
+                         .color1 = color1 + other.color1,
+                         .color2 = color2 + other.color2};
+}
+
+ShapeCorners::OutlineConfig ShapeCorners::OutlineConfig::operator-(const OutlineConfig &other) const
+{
+    return OutlineConfig{.size   = size - other.size,
+                         .angle  = angle - other.angle,
+                         .color1 = color1 - other.color1,
+                         .color2 = color2 - other.color2};
+}
+
+ShapeCorners::OutlineConfig ShapeCorners::OutlineConfig::operator*(const float scalar) const
+{
+    return OutlineConfig{
+            .size = size * scalar, .angle = angle * scalar, .color1 = color1 * scalar, .color2 = color2 * scalar};
+}
+
+ShapeCorners::OutlineConfig ShapeCorners::OutlineConfig::operator/(const float scalar) const
+{
+    return OutlineConfig{
+            .size = size / scalar, .angle = angle / scalar, .color1 = color1 / scalar, .color2 = color2 / scalar};
+}
+
+void ShapeCorners::OutlineConfig::operator+=(const OutlineConfig &other)
+{
+    size += other.size;
+    angle += other.angle;
+    color1 += other.color1;
+    color2 += other.color2;
+}
+
+bool ShapeCorners::OutlineConfig::operator!() const { return size <= 0 && !color1 && !color2; }
+
+void ShapeCorners::OutlineConfig::round()
+{
+    size  = ::round_two_decimal(size);
+    angle = ::round_two_decimal(angle);
+    color1.round();
+    color2.round();
+}
+
+void ShapeCorners::OutlineConfig::clamp(const OutlineConfig &direction, const OutlineConfig &destination)
+{
+    size  = ::clamp(size, direction.size, destination.size);
+    angle = ::clamp(angle, direction.angle, destination.angle);
+    color1.clamp();
+    color2.clamp();
+}
+
 ShapeCorners::WindowConfig ShapeCorners::WindowConfig::activeWindowConfig()
 {
-    const QPalette &m_palette = m_widget.palette();
-    WindowConfig    config    = {
-                  .cornerRadius      = static_cast<float>(Config::size()),
-                  .shadowSize        = static_cast<float>(Config::shadowSize()),
-                  .outlineSize       = static_cast<float>(Config::outlineThickness()),
-                  .secondOutlineSize = static_cast<float>(Config::secondOutlineThickness()),
-                  .outerOutlineSize  = static_cast<float>(Config::outerOutlineThickness()),
-                  .shadowColor       = FloatColor(
-                    Config::activeShadowUsePalette()
-                            ? m_palette.color(QPalette::Active,
-                                                          static_cast<QPalette::ColorRole>(Config::activeShadowPalette()))
-                            : Config::shadowColor()),
-                  .outlineColor = FloatColor(
-                    Config::activeOutlineUsePalette()
-                            ? m_palette.color(QPalette::Active,
-                                                    static_cast<QPalette::ColorRole>(Config::activeOutlinePalette()))
-                            : Config::outlineColor()),
-                  .secondOutlineColor = FloatColor(
-                    Config::activeSecondOutlineUsePalette()
-                            ? m_palette.color(QPalette::Active,
-                                                    static_cast<QPalette::ColorRole>(Config::activeSecondOutlinePalette()))
-                            : Config::secondOutlineColor()),
-                  .outerOutlineColor = FloatColor(
-                    Config::activeOuterOutlineUsePalette()
-                            ? m_palette.color(QPalette::Active,
-                                                    static_cast<QPalette::ColorRole>(Config::activeOuterOutlinePalette()))
-                            : Config::outerOutlineColor()),
-    };
-    config.shadowColor.setAlpha(Config::activeShadowAlpha());
-    config.outlineColor.setAlpha(Config::activeOutlineAlpha());
-    config.secondOutlineColor.setAlpha(Config::activeSecondOutlineAlpha());
-    config.outerOutlineColor.setAlpha(Config::activeOuterOutlineAlpha());
+    const QPalette                &palette = m_widget.palette();
+    constexpr QPalette::ColorGroup group   = QPalette::Active;
+
+    WindowConfig config;
+    config.cornerRadius = static_cast<float>(Config::size());
+    config.shadowSize   = static_cast<float>(Config::shadowSize());
+    config.shadowColor  = resolveColor(palette, group, Config::activeShadowUsePalette(), Config::activeShadowPalette(),
+                                       Config::shadowColor(), Config::activeShadowAlpha());
+
+    config.outline.size = static_cast<float>(Config::outlineThickness());
+    config.outline.color1 =
+            resolveColor(palette, group, Config::activeOutlineUsePalette(), Config::activeOutlinePalette(),
+                         Config::outlineColor(), Config::activeOutlineAlpha());
+    applyGradient(config.outline, Config::outlineIsGradient(), Config::outlineColor2(), Config::outlineGradientAngle());
+
+    config.secondOutline.size = static_cast<float>(Config::secondOutlineThickness());
+    config.secondOutline.color1 =
+            resolveColor(palette, group, Config::activeSecondOutlineUsePalette(), Config::activeSecondOutlinePalette(),
+                         Config::secondOutlineColor(), Config::activeSecondOutlineAlpha());
+    applyGradient(config.secondOutline, Config::secondOutlineIsGradient(), Config::secondOutlineColor2(),
+                  Config::secondOutlineGradientAngle());
+
+    config.outerOutline.size = static_cast<float>(Config::outerOutlineThickness());
+    config.outerOutline.color1 =
+            resolveColor(palette, group, Config::activeOuterOutlineUsePalette(), Config::activeOuterOutlinePalette(),
+                         Config::outerOutlineColor(), Config::activeOuterOutlineAlpha());
+    applyGradient(config.outerOutline, Config::outerOutlineIsGradient(), Config::outerOutlineColor2(),
+                  Config::outerOutlineGradientAngle());
+
     return config;
 }
 
 ShapeCorners::WindowConfig ShapeCorners::WindowConfig::inactiveWindowConfig()
 {
-    const QPalette &m_palette = m_widget.palette();
-    WindowConfig    config    = {
-                  .cornerRadius      = static_cast<float>(Config::inactiveCornerRadius()),
-                  .shadowSize        = static_cast<float>(Config::inactiveShadowSize()),
-                  .outlineSize       = static_cast<float>(Config::inactiveOutlineThickness()),
-                  .secondOutlineSize = static_cast<float>(Config::inactiveSecondOutlineThickness()),
-                  .outerOutlineSize  = static_cast<float>(Config::inactiveOuterOutlineThickness()),
-                  .shadowColor       = FloatColor(
-                    Config::inactiveShadowUsePalette()
-                            ? m_palette.color(QPalette::Inactive,
-                                                          static_cast<QPalette::ColorRole>(Config::inactiveShadowPalette()))
-                            : Config::inactiveShadowColor()),
-                  .outlineColor = FloatColor(
-                    Config::inactiveOutlineUsePalette()
-                            ? m_palette.color(QPalette::Inactive,
-                                                    static_cast<QPalette::ColorRole>(Config::inactiveOutlinePalette()))
-                            : Config::inactiveOutlineColor()),
-                  .secondOutlineColor = FloatColor(
-                    Config::inactiveSecondOutlineUsePalette()
-                            ? m_palette.color(QPalette::Inactive,
-                                                    static_cast<QPalette::ColorRole>(Config::inactiveSecondOutlinePalette()))
-                            : Config::inactiveSecondOutlineColor()),
-                  .outerOutlineColor = FloatColor(
-                    Config::inactiveOuterOutlineUsePalette()
-                            ? m_palette.color(QPalette::Inactive,
-                                                    static_cast<QPalette::ColorRole>(Config::inactiveOuterOutlinePalette()))
-                            : Config::inactiveOuterOutlineColor()),
-    };
-    config.shadowColor.setAlpha(Config::inactiveShadowAlpha());
-    config.outlineColor.setAlpha(Config::inactiveOutlineAlpha());
-    config.secondOutlineColor.setAlpha(Config::inactiveSecondOutlineAlpha());
-    config.outerOutlineColor.setAlpha(Config::inactiveOuterOutlineAlpha());
+    const QPalette                &palette = m_widget.palette();
+    constexpr QPalette::ColorGroup group   = QPalette::Inactive;
+
+    WindowConfig config;
+    config.cornerRadius = static_cast<float>(Config::inactiveCornerRadius());
+    config.shadowSize   = static_cast<float>(Config::inactiveShadowSize());
+    config.shadowColor =
+            resolveColor(palette, group, Config::inactiveShadowUsePalette(), Config::inactiveShadowPalette(),
+                         Config::inactiveShadowColor(), Config::inactiveShadowAlpha());
+
+    config.outline.size = static_cast<float>(Config::inactiveOutlineThickness());
+    config.outline.color1 =
+            resolveColor(palette, group, Config::inactiveOutlineUsePalette(), Config::inactiveOutlinePalette(),
+                         Config::inactiveOutlineColor(), Config::inactiveOutlineAlpha());
+    applyGradient(config.outline, Config::inactiveOutlineIsGradient(), Config::inactiveOutlineColor2(),
+                  Config::inactiveOutlineGradientAngle());
+
+    config.secondOutline.size   = static_cast<float>(Config::inactiveSecondOutlineThickness());
+    config.secondOutline.color1 = resolveColor(
+            palette, group, Config::inactiveSecondOutlineUsePalette(), Config::inactiveSecondOutlinePalette(),
+            Config::inactiveSecondOutlineColor(), Config::inactiveSecondOutlineAlpha());
+    applyGradient(config.secondOutline, Config::inactiveSecondOutlineIsGradient(),
+                  Config::inactiveSecondOutlineColor2(), Config::inactiveSecondOutlineGradientAngle());
+
+    config.outerOutline.size   = static_cast<float>(Config::inactiveOuterOutlineThickness());
+    config.outerOutline.color1 = resolveColor(palette, group, Config::inactiveOuterOutlineUsePalette(),
+                                              Config::inactiveOuterOutlinePalette(),
+                                              Config::inactiveOuterOutlineColor(), Config::inactiveOuterOutlineAlpha());
+    applyGradient(config.outerOutline, Config::inactiveOuterOutlineIsGradient(), Config::inactiveOuterOutlineColor2(),
+                  Config::inactiveOuterOutlineGradientAngle());
+
     return config;
 }
 
 ShapeCorners::WindowConfig ShapeCorners::WindowConfig::operator+(const WindowConfig &other) const
 {
-    return WindowConfig{.cornerRadius       = cornerRadius + other.cornerRadius,
-                        .shadowSize         = shadowSize + other.shadowSize,
-                        .outlineSize        = outlineSize + other.outlineSize,
-                        .secondOutlineSize  = secondOutlineSize + other.secondOutlineSize,
-                        .outerOutlineSize   = outerOutlineSize + other.outerOutlineSize,
-                        .shadowColor        = shadowColor + other.shadowColor,
-                        .outlineColor       = outlineColor + other.outlineColor,
-                        .secondOutlineColor = secondOutlineColor + other.secondOutlineColor,
-                        .outerOutlineColor  = outerOutlineColor + other.outerOutlineColor};
+    return WindowConfig{.cornerRadius  = cornerRadius + other.cornerRadius,
+                        .shadowSize    = shadowSize + other.shadowSize,
+                        .shadowColor   = shadowColor + other.shadowColor,
+                        .outline       = outline + other.outline,
+                        .secondOutline = secondOutline + other.secondOutline,
+                        .outerOutline  = outerOutline + other.outerOutline};
 }
 
 ShapeCorners::WindowConfig ShapeCorners::WindowConfig::operator-(const WindowConfig &other) const
 {
-    return WindowConfig{.cornerRadius       = cornerRadius - other.cornerRadius,
-                        .shadowSize         = shadowSize - other.shadowSize,
-                        .outlineSize        = outlineSize - other.outlineSize,
-                        .secondOutlineSize  = secondOutlineSize - other.secondOutlineSize,
-                        .outerOutlineSize   = outerOutlineSize - other.outerOutlineSize,
-                        .shadowColor        = shadowColor - other.shadowColor,
-                        .outlineColor       = outlineColor - other.outlineColor,
-                        .secondOutlineColor = secondOutlineColor - other.secondOutlineColor,
-                        .outerOutlineColor  = outerOutlineColor - other.outerOutlineColor};
+    return WindowConfig{.cornerRadius  = cornerRadius - other.cornerRadius,
+                        .shadowSize    = shadowSize - other.shadowSize,
+                        .shadowColor   = shadowColor - other.shadowColor,
+                        .outline       = outline - other.outline,
+                        .secondOutline = secondOutline - other.secondOutline,
+                        .outerOutline  = outerOutline - other.outerOutline};
 }
 
 ShapeCorners::WindowConfig ShapeCorners::WindowConfig::operator*(const float scalar) const
 {
-    return WindowConfig{.cornerRadius       = cornerRadius * scalar,
-                        .shadowSize         = shadowSize * scalar,
-                        .outlineSize        = outlineSize * scalar,
-                        .secondOutlineSize  = secondOutlineSize * scalar,
-                        .outerOutlineSize   = outerOutlineSize * scalar,
-                        .shadowColor        = shadowColor * scalar,
-                        .outlineColor       = outlineColor * scalar,
-                        .secondOutlineColor = secondOutlineColor * scalar,
-                        .outerOutlineColor  = outerOutlineColor * scalar};
+    return WindowConfig{.cornerRadius  = cornerRadius * scalar,
+                        .shadowSize    = shadowSize * scalar,
+                        .shadowColor   = shadowColor * scalar,
+                        .outline       = outline * scalar,
+                        .secondOutline = secondOutline * scalar,
+                        .outerOutline  = outerOutline * scalar};
 }
 
 ShapeCorners::WindowConfig ShapeCorners::WindowConfig::operator/(const float scalar) const
 {
-    return WindowConfig{.cornerRadius       = cornerRadius / scalar,
-                        .shadowSize         = shadowSize / scalar,
-                        .outlineSize        = outlineSize / scalar,
-                        .secondOutlineSize  = secondOutlineSize / scalar,
-                        .outerOutlineSize   = outerOutlineSize / scalar,
-                        .shadowColor        = shadowColor / scalar,
-                        .outlineColor       = outlineColor / scalar,
-                        .secondOutlineColor = secondOutlineColor / scalar,
-                        .outerOutlineColor  = outerOutlineColor / scalar};
+    return WindowConfig{.cornerRadius  = cornerRadius / scalar,
+                        .shadowSize    = shadowSize / scalar,
+                        .shadowColor   = shadowColor / scalar,
+                        .outline       = outline / scalar,
+                        .secondOutline = secondOutline / scalar,
+                        .outerOutline  = outerOutline / scalar};
 }
 
 bool ShapeCorners::WindowConfig::operator!() const
 {
-    return cornerRadius <= 0 && shadowSize <= 0 && outlineSize <= 0 && secondOutlineSize <= 0 &&
-           outerOutlineSize <= 0 && !shadowColor && !outlineColor && !secondOutlineColor && !outerOutlineColor;
+    return cornerRadius <= 0 && shadowSize <= 0 && !shadowColor && !outline && !secondOutline && !outerOutline;
 }
 
 void ShapeCorners::WindowConfig::operator+=(const WindowConfig &other)
 {
     cornerRadius += other.cornerRadius;
     shadowSize += other.shadowSize;
-    outlineSize += other.outlineSize;
-    secondOutlineSize += other.secondOutlineSize;
-    outerOutlineSize += other.outerOutlineSize;
     shadowColor += other.shadowColor;
-    outlineColor += other.outlineColor;
-    secondOutlineColor += other.secondOutlineColor;
-    outerOutlineColor += other.outerOutlineColor;
+    outline += other.outline;
+    secondOutline += other.secondOutline;
+    outerOutline += other.outerOutline;
 }
 
 void ShapeCorners::WindowConfig::round()
 {
-    cornerRadius      = ::round_two_decimal(cornerRadius);
-    shadowSize        = ::round_two_decimal(shadowSize);
-    outlineSize       = ::round_two_decimal(outlineSize);
-    secondOutlineSize = ::round_two_decimal(secondOutlineSize);
-    outerOutlineSize  = ::round_two_decimal(outerOutlineSize);
+    cornerRadius = ::round_two_decimal(cornerRadius);
+    shadowSize   = ::round_two_decimal(shadowSize);
     shadowColor.round();
-    outlineColor.round();
-    secondOutlineColor.round();
-    outerOutlineColor.round();
+    outline.round();
+    secondOutline.round();
+    outerOutline.round();
 }
 
 void ShapeCorners::WindowConfig::clamp(const WindowConfig &direction, const WindowConfig &destination)
 {
-    cornerRadius      = ::clamp(cornerRadius, direction.cornerRadius, destination.cornerRadius);
-    shadowSize        = ::clamp(shadowSize, direction.shadowSize, destination.shadowSize);
-    outlineSize       = ::clamp(outlineSize, direction.outlineSize, destination.outlineSize);
-    secondOutlineSize = ::clamp(secondOutlineSize, direction.secondOutlineSize, destination.secondOutlineSize);
-    outerOutlineSize  = ::clamp(outerOutlineSize, direction.outerOutlineSize, destination.outerOutlineSize);
+    cornerRadius = ::clamp(cornerRadius, direction.cornerRadius, destination.cornerRadius);
+    shadowSize   = ::clamp(shadowSize, direction.shadowSize, destination.shadowSize);
     shadowColor.clamp();
-    outlineColor.clamp();
-    secondOutlineColor.clamp();
-    outerOutlineColor.clamp();
+    outline.clamp(direction.outline, destination.outline);
+    secondOutline.clamp(direction.secondOutline, destination.secondOutline);
+    outerOutline.clamp(direction.outerOutline, destination.outerOutline);
 }

--- a/src/WindowConfig.h
+++ b/src/WindowConfig.h
@@ -1,9 +1,10 @@
 /**
  * @file WindowConfig.h
- * @brief Declares the ShapeCorners::WindowConfig struct for storing window appearance configuration.
+ * @brief Declares the ShapeCorners::WindowConfig and ShapeCorners::OutlineConfig structs.
  *
- * This struct holds all configurable properties for a window's appearance in the ShapeCorners KWin effect,
- * including corner radius, shadow, and outline settings.
+ * These structs hold all configurable properties for a window's appearance in the ShapeCorners KWin effect,
+ * including corner radius, shadow, and outline settings. OutlineConfig groups the per-outline properties
+ * (thickness and a two-stop linear gradient) so they can be reused for each of the three outlines.
  */
 
 #pragma once
@@ -13,10 +14,81 @@
 namespace ShapeCorners
 {
     /**
+     * @struct OutlineConfig
+     * @brief Stores one outline's thickness and its two-stop linear gradient.
+     *
+     * When the outline is a solid color, both gradient stops are equal. Provides the same
+     * arithmetic operators as WindowConfig so active/inactive states can be interpolated per outline.
+     */
+    struct OutlineConfig {
+        /**
+         * @brief Outline thickness in pixels.
+         */
+        float size{};
+
+        /**
+         * @brief Gradient angle in degrees. 0 = left to right, 90 = top to bottom.
+         */
+        float angle{};
+
+        /**
+         * @brief First gradient stop color.
+         */
+        FloatColor color1;
+
+        /**
+         * @brief Second gradient stop color. Equal to color1 when the outline is a solid color.
+         */
+        FloatColor color2;
+
+        /**
+         * @brief Adds two OutlineConfig objects.
+         */
+        OutlineConfig operator+(const OutlineConfig &other) const;
+
+        /**
+         * @brief Subtracts another OutlineConfig from this one.
+         */
+        OutlineConfig operator-(const OutlineConfig &other) const;
+
+        /**
+         * @brief Multiplies all fields by a scalar.
+         */
+        OutlineConfig operator*(float scalar) const;
+
+        /**
+         * @brief Divides all fields by a scalar.
+         */
+        OutlineConfig operator/(float scalar) const;
+
+        /**
+         * @brief Adds another OutlineConfig to this one in-place.
+         */
+        void operator+=(const OutlineConfig &other);
+
+        /**
+         * @brief Checks whether this outline draws nothing (zero size and transparent stops).
+         * @note The gradient angle is not considered; it does not affect whether anything is drawn.
+         */
+        [[nodiscard]]
+        bool operator!() const;
+
+        /**
+         * @brief Rounds all floating-point fields.
+         */
+        void round();
+
+        /**
+         * @brief Clamps all fields to the range defined by direction and destination configs.
+         */
+        void clamp(const OutlineConfig &direction, const OutlineConfig &destination);
+    };
+
+    /**
      * @struct WindowConfig
      * @brief Stores configuration for a window's appearance and animation.
      *
-     * Holds values for corner radius, shadow size/color, outline thickness/color, and second outline.
+     * Holds values for corner radius, shadow size/color, and the three outlines.
      * Provides arithmetic operators and utility methods for animation and value clamping.
      */
     struct WindowConfig {
@@ -31,39 +103,24 @@ namespace ShapeCorners
         float shadowSize{};
 
         /**
-         * @brief Current outline thickness.
-         */
-        float outlineSize{};
-
-        /**
-         * @brief Current second outline thickness.
-         */
-        float secondOutlineSize{};
-
-        /**
-         * @brief Current outer outline thickness.
-         */
-        float outerOutlineSize{};
-
-        /**
          * @brief Current shadow color.
          */
         FloatColor shadowColor;
 
         /**
-         * @brief Current outline color.
+         * @brief Current primary outline configuration.
          */
-        FloatColor outlineColor;
+        OutlineConfig outline;
 
         /**
-         * @brief Current second outline color.
+         * @brief Current second outline configuration.
          */
-        FloatColor secondOutlineColor;
+        OutlineConfig secondOutline;
 
         /**
-         * @brief Current outer outline color.
+         * @brief Current outer outline configuration.
          */
-        FloatColor outerOutlineColor;
+        OutlineConfig outerOutline;
 
         /**
          * @brief Returns the configuration for an active window.

--- a/src/kcm/KCM.cpp
+++ b/src/kcm/KCM.cpp
@@ -94,6 +94,34 @@ ShapeCorners::KCM::KCM(QWidget *parent, const QVariantList &args) : KCModule(par
         ui->kcfg_Squircleness->setEnabled(useSquircle);
     });
 
+    // Show each outline's gradient controls (second color + angle) only while its "Gradient" box is ticked.
+    const auto wireGradientDisclosure = [this](QAbstractButton *toggle, const QList<QWidget *> &widgets) {
+        const auto apply = [toggle, widgets] {
+            for (auto *const widget: widgets) {
+                widget->setVisible(toggle->isChecked());
+            }
+        };
+        connect(toggle, &QAbstractButton::toggled, this, apply);
+        apply();
+    };
+    wireGradientDisclosure(ui->kcfg_OutlineIsGradient, {ui->label_OutlineColor2, ui->kcfg_OutlineColor2,
+                                                        ui->label_OutlineAngle, ui->kcfg_OutlineGradientAngle});
+    wireGradientDisclosure(ui->kcfg_InactiveOutlineIsGradient,
+                           {ui->label_InactiveOutlineColor2, ui->kcfg_InactiveOutlineColor2,
+                            ui->label_InactiveOutlineAngle, ui->kcfg_InactiveOutlineGradientAngle});
+    wireGradientDisclosure(ui->kcfg_SecondOutlineIsGradient,
+                           {ui->label_SecondOutlineColor2, ui->kcfg_SecondOutlineColor2, ui->label_SecondOutlineAngle,
+                            ui->kcfg_SecondOutlineGradientAngle});
+    wireGradientDisclosure(ui->kcfg_InactiveSecondOutlineIsGradient,
+                           {ui->label_InactiveSecondOutlineColor2, ui->kcfg_InactiveSecondOutlineColor2,
+                            ui->label_InactiveSecondOutlineAngle, ui->kcfg_InactiveSecondOutlineGradientAngle});
+    wireGradientDisclosure(ui->kcfg_OuterOutlineIsGradient,
+                           {ui->label_OuterOutlineColor2, ui->kcfg_OuterOutlineColor2, ui->label_OuterOutlineAngle,
+                            ui->kcfg_OuterOutlineGradientAngle});
+    wireGradientDisclosure(ui->kcfg_InactiveOuterOutlineIsGradient,
+                           {ui->label_InactiveOuterOutlineColor2, ui->kcfg_InactiveOuterOutlineColor2,
+                            ui->label_InactiveOuterOutlineAngle, ui->kcfg_InactiveOuterOutlineGradientAngle});
+
     // It was expected that the Apply button would get enabled automatically as the gradient sliders move, but it
     // doesn't. Maybe it is a bug on the KCM side. Need to check and delete these lines later.
     connect(ui->kcfg_ActiveShadowAlpha, &KGradientSelector::sliderMoved, this, &KCM::markAsChanged);

--- a/src/kcm/KCM.ui
+++ b/src/kcm/KCM.ui
@@ -10,12 +10,6 @@
     <height>700</height>
    </rect>
   </property>
-  <property name="maximumSize">
-   <size>
-    <width>16777215</width>
-    <height>700</height>
-   </size>
-  </property>
   <property name="windowTitle">
    <string>Rounded Corners (formerly ShapeCorners)</string>
   </property>
@@ -1028,6 +1022,47 @@
                    <item row="3" column="1">
                     <widget class="KColorButton" name="kcfg_OutlineColor"/>
                    </item>
+                   <item row="4" column="0">
+                    <widget class="QCheckBox" name="kcfg_OutlineIsGradient">
+                     <property name="text">
+                      <string>&amp;Gradient</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="5" column="0">
+                    <widget class="QLabel" name="label_OutlineColor2">
+                     <property name="text">
+                      <string>Second Color</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="5" column="1">
+                    <widget class="KColorButton" name="kcfg_OutlineColor2">
+                     <property name="alphaChannelEnabled">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="6" column="0">
+                    <widget class="QLabel" name="label_OutlineAngle">
+                     <property name="text">
+                      <string>Gradient Angle</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="6" column="1">
+                    <widget class="QSpinBox" name="kcfg_OutlineGradientAngle">
+                     <property name="suffix">
+                      <string>°</string>
+                     </property>
+                     <property name="maximum">
+                      <number>360</number>
+                     </property>
+                     <property name="wrapping">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
                    <item row="3" column="0">
                     <widget class="QRadioButton" name="kcfg_ActiveOutlineUseCustom">
                      <property name="text">
@@ -1257,6 +1292,47 @@
                    </item>
                    <item row="3" column="1">
                     <widget class="KColorButton" name="kcfg_InactiveOutlineColor"/>
+                   </item>
+                   <item row="4" column="0">
+                    <widget class="QCheckBox" name="kcfg_InactiveOutlineIsGradient">
+                     <property name="text">
+                      <string>&amp;Gradient</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="5" column="0">
+                    <widget class="QLabel" name="label_InactiveOutlineColor2">
+                     <property name="text">
+                      <string>Second Color</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="5" column="1">
+                    <widget class="KColorButton" name="kcfg_InactiveOutlineColor2">
+                     <property name="alphaChannelEnabled">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="6" column="0">
+                    <widget class="QLabel" name="label_InactiveOutlineAngle">
+                     <property name="text">
+                      <string>Gradient Angle</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="6" column="1">
+                    <widget class="QSpinBox" name="kcfg_InactiveOutlineGradientAngle">
+                     <property name="suffix">
+                      <string>°</string>
+                     </property>
+                     <property name="maximum">
+                      <number>360</number>
+                     </property>
+                     <property name="wrapping">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
                    </item>
                   </layout>
                  </item>
@@ -1496,6 +1572,47 @@
                    <item row="3" column="1">
                     <widget class="KColorButton" name="kcfg_SecondOutlineColor"/>
                    </item>
+                   <item row="4" column="0">
+                    <widget class="QCheckBox" name="kcfg_SecondOutlineIsGradient">
+                     <property name="text">
+                      <string>&amp;Gradient</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="5" column="0">
+                    <widget class="QLabel" name="label_SecondOutlineColor2">
+                     <property name="text">
+                      <string>Second Color</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="5" column="1">
+                    <widget class="KColorButton" name="kcfg_SecondOutlineColor2">
+                     <property name="alphaChannelEnabled">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="6" column="0">
+                    <widget class="QLabel" name="label_SecondOutlineAngle">
+                     <property name="text">
+                      <string>Gradient Angle</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="6" column="1">
+                    <widget class="QSpinBox" name="kcfg_SecondOutlineGradientAngle">
+                     <property name="suffix">
+                      <string>°</string>
+                     </property>
+                     <property name="maximum">
+                      <number>360</number>
+                     </property>
+                     <property name="wrapping">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
                   </layout>
                  </item>
                 </layout>
@@ -1718,6 +1835,47 @@
                    </item>
                    <item row="3" column="1">
                     <widget class="KColorButton" name="kcfg_InactiveSecondOutlineColor"/>
+                   </item>
+                   <item row="4" column="0">
+                    <widget class="QCheckBox" name="kcfg_InactiveSecondOutlineIsGradient">
+                     <property name="text">
+                      <string>&amp;Gradient</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="5" column="0">
+                    <widget class="QLabel" name="label_InactiveSecondOutlineColor2">
+                     <property name="text">
+                      <string>Second Color</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="5" column="1">
+                    <widget class="KColorButton" name="kcfg_InactiveSecondOutlineColor2">
+                     <property name="alphaChannelEnabled">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="6" column="0">
+                    <widget class="QLabel" name="label_InactiveSecondOutlineAngle">
+                     <property name="text">
+                      <string>Gradient Angle</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="6" column="1">
+                    <widget class="QSpinBox" name="kcfg_InactiveSecondOutlineGradientAngle">
+                     <property name="suffix">
+                      <string>°</string>
+                     </property>
+                     <property name="maximum">
+                      <number>360</number>
+                     </property>
+                     <property name="wrapping">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
                    </item>
                   </layout>
                  </item>
@@ -1957,6 +2115,47 @@
                    <item row="3" column="1">
                     <widget class="KColorButton" name="kcfg_OuterOutlineColor"/>
                    </item>
+                   <item row="4" column="0">
+                    <widget class="QCheckBox" name="kcfg_OuterOutlineIsGradient">
+                     <property name="text">
+                      <string>&amp;Gradient</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="5" column="0">
+                    <widget class="QLabel" name="label_OuterOutlineColor2">
+                     <property name="text">
+                      <string>Second Color</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="5" column="1">
+                    <widget class="KColorButton" name="kcfg_OuterOutlineColor2">
+                     <property name="alphaChannelEnabled">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="6" column="0">
+                    <widget class="QLabel" name="label_OuterOutlineAngle">
+                     <property name="text">
+                      <string>Gradient Angle</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="6" column="1">
+                    <widget class="QSpinBox" name="kcfg_OuterOutlineGradientAngle">
+                     <property name="suffix">
+                      <string>°</string>
+                     </property>
+                     <property name="maximum">
+                      <number>360</number>
+                     </property>
+                     <property name="wrapping">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
                   </layout>
                  </item>
                 </layout>
@@ -2179,6 +2378,47 @@
                    </item>
                    <item row="3" column="1">
                     <widget class="KColorButton" name="kcfg_InactiveOuterOutlineColor"/>
+                   </item>
+                   <item row="4" column="0">
+                    <widget class="QCheckBox" name="kcfg_InactiveOuterOutlineIsGradient">
+                     <property name="text">
+                      <string>&amp;Gradient</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="5" column="0">
+                    <widget class="QLabel" name="label_InactiveOuterOutlineColor2">
+                     <property name="text">
+                      <string>Second Color</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="5" column="1">
+                    <widget class="KColorButton" name="kcfg_InactiveOuterOutlineColor2">
+                     <property name="alphaChannelEnabled">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="6" column="0">
+                    <widget class="QLabel" name="label_InactiveOuterOutlineAngle">
+                     <property name="text">
+                      <string>Gradient Angle</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="6" column="1">
+                    <widget class="QSpinBox" name="kcfg_InactiveOuterOutlineGradientAngle">
+                     <property name="suffix">
+                      <string>°</string>
+                     </property>
+                     <property name="maximum">
+                      <number>360</number>
+                     </property>
+                     <property name="wrapping">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
                    </item>
                   </layout>
                  </item>

--- a/src/kcm/options.kcfg
+++ b/src/kcm/options.kcfg
@@ -121,6 +121,31 @@
             <default>true</default>
         </entry>
 
+        <!-- Primary Outline Gradient (second stop is custom-color only) -->
+
+        <entry name="OutlineIsGradient" type="Bool">
+            <default>false</default>
+        </entry>
+        <entry name="InactiveOutlineIsGradient" type="Bool">
+            <default>false</default>
+        </entry>
+        <entry name="OutlineColor2" type="Color">
+            <default>black</default>
+        </entry>
+        <entry name="InactiveOutlineColor2" type="Color">
+            <default>black</default>
+        </entry>
+        <entry name="OutlineGradientAngle" type="Int">
+            <default>45</default>
+            <min>0</min>
+            <max>360</max>
+        </entry>
+        <entry name="InactiveOutlineGradientAngle" type="Int">
+            <default>45</default>
+            <min>0</min>
+            <max>360</max>
+        </entry>
+
         <!-- Second Outline Options -->
 
         <entry name="SecondOutlineThickness" type="Double">
@@ -168,6 +193,31 @@
             <default>true</default>
         </entry>
 
+        <!-- Second Outline Gradient (second stop is custom-color only) -->
+
+        <entry name="SecondOutlineIsGradient" type="Bool">
+            <default>false</default>
+        </entry>
+        <entry name="InactiveSecondOutlineIsGradient" type="Bool">
+            <default>false</default>
+        </entry>
+        <entry name="SecondOutlineColor2" type="Color">
+            <default>white</default>
+        </entry>
+        <entry name="InactiveSecondOutlineColor2" type="Color">
+            <default>white</default>
+        </entry>
+        <entry name="SecondOutlineGradientAngle" type="Int">
+            <default>45</default>
+            <min>0</min>
+            <max>360</max>
+        </entry>
+        <entry name="InactiveSecondOutlineGradientAngle" type="Int">
+            <default>45</default>
+            <min>0</min>
+            <max>360</max>
+        </entry>
+
         <!-- Outer Outline Options -->
 
         <entry name="OuterOutlineThickness" type="Double">
@@ -213,6 +263,31 @@
         </entry>
         <entry name="InactiveOuterOutlineUseCustom" type="Bool">
             <default>true</default>
+        </entry>
+
+        <!-- Outer Outline Gradient (second stop is custom-color only) -->
+
+        <entry name="OuterOutlineIsGradient" type="Bool">
+            <default>false</default>
+        </entry>
+        <entry name="InactiveOuterOutlineIsGradient" type="Bool">
+            <default>false</default>
+        </entry>
+        <entry name="OuterOutlineColor2" type="Color">
+            <default>black</default>
+        </entry>
+        <entry name="InactiveOuterOutlineColor2" type="Color">
+            <default>black</default>
+        </entry>
+        <entry name="OuterOutlineGradientAngle" type="Int">
+            <default>45</default>
+            <min>0</min>
+            <max>360</max>
+        </entry>
+        <entry name="InactiveOuterOutlineGradientAngle" type="Int">
+            <default>45</default>
+            <min>0</min>
+            <max>360</max>
         </entry>
 
         <!-- Inclusion and Exclusion Options -->

--- a/src/shaders/shapecorners.glsl
+++ b/src/shaders/shapecorners.glsl
@@ -30,6 +30,21 @@ float shape_distance(vec2 point, vec2 center, float radius)
 }
 
 /*
+ *  \brief Linear gradient color sampled along an axis across the window frame.
+ *  \param c1: The color at the start of the gradient.
+ *  \param c2: The color at the end of the gradient. When equal to c1 this returns a solid color.
+ *  \param angleDeg: The gradient direction in degrees. 0 = left->right, 90 = top->bottom.
+ *  \param coord0: The XY pixel being shaded, in window-frame pixels (see tex_to_pixel).
+ *  \return The interpolated RGBA color at that pixel.
+ */
+vec4 gradientColor(vec4 c1, vec4 c2, float angleDeg, vec2 coord0)
+{
+    vec2  dir = vec2(cos(radians(angleDeg)), sin(radians(angleDeg)));
+    float t   = dot(coord0 / windowSize - 0.5, dir) + 0.5;
+    return mix(c1, c2, clamp(t, 0.0, 1.0));
+}
+
+/*
  *  \brief This function is used to choose the pixel color based on its distance to the center input.
  *  \param coord0: The XY point
  *  \param tex: The RGBA color of the pixel in XY
@@ -41,6 +56,12 @@ float shape_distance(vec2 point, vec2 center, float radius)
  */
 vec4 shapeCorner(vec2 coord0, vec4 tex, vec2 start, float angle, vec4 coord_shadowColor)
 {
+    // Resolve each outline's gradient once; the logic below then treats them as solid colors.
+    // When an outline is not a gradient its two stops are equal, so these collapse to plain solids.
+    vec4 outlineColor       = gradientColor(outlineColor1, outlineColor2, outlineAngle, coord0);
+    vec4 secondOutlineColor = gradientColor(secondOutlineColor1, secondOutlineColor2, secondOutlineAngle, coord0);
+    vec4 outerOutlineColor  = gradientColor(outerOutlineColor1, outerOutlineColor2, outerOutlineAngle, coord0);
+
     vec2  angle_vector         = vec2(cos(angle), sin(angle));
     float corner_length        = (abs(angle_vector.x) < 0.1 || abs(angle_vector.y) < 0.1) ? 1.0 : sqrt(2.0);
     vec2  roundness_center     = start + radius * angle_vector * corner_length;

--- a/src/shaders/variables.glsl
+++ b/src/shaders/variables.glsl
@@ -7,11 +7,17 @@ uniform vec2 windowTopLeft; /* The distance between the top-left of `expandedGeo
                              * the top-left of `frameGeometry`. When `windowTopLeft = {0,0}`, it means
                              * `expandedGeometry = frameGeometry` and there is no shadow. */
 
-uniform vec4  outlineColor;           // The RGBA of the outline color specified in settings.
+uniform vec4  outlineColor1;          // The RGBA of the outline's first gradient stop specified in settings.
+uniform vec4  outlineColor2;          // The RGBA of the outline's second gradient stop. Equals stop 1 when not a gradient.
+uniform float outlineAngle;           // The outline gradient angle in degrees. 0 = left->right, 90 = top->bottom.
 uniform float outlineThickness;       // The thickness of the outline in pixels specified in settings.
-uniform vec4  secondOutlineColor;     // The RGBA of the second outline color specified in settings.
+uniform vec4  secondOutlineColor1;    // The RGBA of the second outline's first gradient stop specified in settings.
+uniform vec4  secondOutlineColor2;    // The RGBA of the second outline's second gradient stop.
+uniform float secondOutlineAngle;     // The second outline gradient angle in degrees.
 uniform float secondOutlineThickness; // The thickness of the second outline in pixels specified in settings.
-uniform vec4  outerOutlineColor;      // The RGBA of the outer outline color specified in settings.
+uniform vec4  outerOutlineColor1;     // The RGBA of the outer outline's first gradient stop specified in settings.
+uniform vec4  outerOutlineColor2;     // The RGBA of the outer outline's second gradient stop.
+uniform float outerOutlineAngle;      // The outer outline gradient angle in degrees.
 uniform float outerOutlineThickness;  // The thickness of the outer outline in pixels specified in settings.
 
 vec2 tex_to_pixel(vec2 texcoord)
@@ -25,6 +31,6 @@ vec2 pixel_to_tex(vec2 pixelcoord)
                 1.0 - (pixelcoord.y + windowTopLeft.y) / windowExpandedSize.y);
 }
 bool hasExpandedSize() { return windowTopLeft.x >= 1.0 && windowTopLeft.y >= 1.0; }
-bool hasPrimaryOutline() { return outlineColor.a > 0.0 && outlineThickness > 0.0; }
-bool hasSecondOutline() { return secondOutlineColor.a > 0.0 && secondOutlineThickness > 0.0; }
-bool hasOuterOutline() { return hasExpandedSize() && outerOutlineColor.a > 0.0 && outerOutlineThickness > 0.0; }
+bool hasPrimaryOutline() { return outlineColor1.a > 0.0 && outlineThickness > 0.0; }
+bool hasSecondOutline() { return secondOutlineColor1.a > 0.0 && secondOutlineThickness > 0.0; }
+bool hasOuterOutline() { return hasExpandedSize() && outerOutlineColor1.a > 0.0 && outerOutlineThickness > 0.0; }


### PR DESCRIPTION
- Linear gradient outlines: each outline can fade between two colors along a configurable angle
- New `OutlineConfig` sub-struct groups per-outline size/angle/color stops with shared arithmetic operators
- Per-outline, per-state config: `IsGradient` toggle, custom second color (with alpha), and gradient angle
- KCM shows the second color + angle only when the outline's Gradient box is ticked
- Shader interpolates the two stops; when not a gradient, the stops are equal, so existing setups render identically
- Fix the config window not growing vertically when maximized
- Docs: gradient outlines, and Launchpad PPA install instructions

Closes #522 and #403