### PR TITLE
Exclude ksmserver-logout-greeter from decoration

### DIFF
--- a/src/WindowManager.cpp
+++ b/src/WindowManager.cpp
@@ -80,9 +80,8 @@ bool ShapeCorners::WindowManager::addWindow(KWin::EffectWindow *kwindow)
             QStringLiteral("kwin"),         QStringLiteral("kwin_x11"),
             QStringLiteral("kwin_wayland"), QStringLiteral("kscreenlocker_greet"),
             QStringLiteral("ksmserver"),    QStringLiteral("krunner"),
-            QStringLiteral("ksplashqml"),
-            // QStringLiteral("plasmashell"),        Note: Don't add it to exceptions,
-            // it involves widget config windows
+            QStringLiteral("ksplashqml"),   QStringLiteral("ksmserver-logout-greeter"),
+            // QStringLiteral("plasmashell")  Note: Don't add it to exceptions, it involves widget config windows.
     };
     const auto name = kwindow->windowClass().split(QChar::Space).first();
     if (hardExceptions.contains(name)) {
@@ -202,10 +201,10 @@ void ShapeCorners::WindowManager::checkMaximized(KWin::EffectWindow *kwindow) co
     const auto maxArea = KWin::effects->clientArea(KWin::MaximizeArea, kwindow);
 
     constexpr qreal tolerance = 1.0;
-    window->isMaximized = qAbs(frame.x() - maxArea.x()) <= tolerance
-                       && qAbs(frame.y() - maxArea.y()) <= tolerance
-                       && qAbs(frame.width() - maxArea.width()) <= tolerance
-                       && qAbs(frame.height() - maxArea.height()) <= tolerance;
+    window->isMaximized       = (qAbs(frame.x() - maxArea.x()) <= tolerance) &&
+                                (qAbs(frame.y() - maxArea.y()) <= tolerance) &&
+                                (qAbs(frame.width() - maxArea.width()) <= tolerance) &&
+                                (qAbs(frame.height() - maxArea.height()) <= tolerance);
 
 #ifdef DEBUG_MAXIMIZED
     qDebug() << "ShapeCorners: maximize area" << maxArea << "window" << kwindow->frameGeometry();


### PR DESCRIPTION
### The issue
- The greeter covers the whole output, including panel struts, so its frame (1536x864) never matches `MaximizeArea` (1536x820), and KWin does not report it as fullscreen. Every branch in `hasRoundCorners()` and `hasOutline()` fell through to the default, so the logout overlay was drawn with rounded corners and an outline.
 - The greeter is a separate binary with its own window class, so the existing `ksmserver` entry never matched it.

### The fix
- Add `ksmserver-logout-greeter` to `hardExceptions` in `WindowManager::addWindow`.