### PR TITLE
Fix fractional scaling when binding the shader

### DIFF
--- a/src/Effect.cpp
+++ b/src/Effect.cpp
@@ -36,6 +36,7 @@
 #else
 #include <kwineffects.h>
 #include <kwinglutils.h>
+#include "Utils.h"
 #endif
 
 void ShapeCorners::Effect::WriteBreezeConfig(bool set_disabled)

--- a/src/Effect.cpp
+++ b/src/Effect.cpp
@@ -25,10 +25,10 @@
 
 #include "Animation.h"
 #include "Config.h"
-#include "Utils.h"
 #include "Window.h"
 #include "WindowManager.h"
 #if QT_VERSION_MAJOR >= 6
+#include <core/output.h>
 #include <core/renderviewport.h>
 #include <effect/effecthandler.h>
 #include <effect/effectwindow.h>
@@ -220,14 +220,14 @@ bool ShapeCorners::Effect::drawWindow(
 #else
 void ShapeCorners::Effect::drawWindow(
 #endif // KWIN_EFFECT_API_VERSION >= 237 && KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 7, 80)
-                                      const KWin::RenderTarget &renderTarget, const KWin::RenderViewport &viewport,
-                                      KWin::EffectWindow *kwindow, int mask,
+        const KWin::RenderTarget &renderTarget, const KWin::RenderViewport &viewport, KWin::EffectWindow *kwindow,
+        int mask,
 #if KWIN_EFFECT_API_VERSION >= 237
-                                      const KWin::Region &region,
+        const KWin::Region &region,
 #else
-                                      const QRegion &region,
+        const QRegion &region,
 #endif
-                                      KWin::WindowPaintData &data)
+        KWin::WindowPaintData &data)
 {
 #else
 void ShapeCorners::Effect::drawWindow(KWin::EffectWindow *kwindow, int mask, const QRegion &region,
@@ -247,14 +247,16 @@ void ShapeCorners::Effect::drawWindow(KWin::EffectWindow *kwindow, int mask, con
         OffscreenEffect::drawWindow(renderTarget, viewport, kwindow, mask, region, data);
         return;
 #else
-        OffscreenEffect::drawWindow(kwindow, mask, region, data);
-        return;
+    OffscreenEffect::drawWindow(kwindow, mask, region, data);
+    return;
 #endif
     }
 
 #if QT_VERSION_MAJOR >= 6
     // Get the scale factor for Qt6.
-    const auto scale = viewport.scale();
+    // KWin renders the offscreen texture at the scale of the screen the window belongs to,
+    // which is not the scale of the output being painted.
+    const auto scale = kwindow->screen()->scale();
 #else
     // Get the scale factor for Qt5.
     const auto scale = KWin::effects->renderTargetScale();
@@ -275,7 +277,7 @@ void ShapeCorners::Effect::drawWindow(KWin::EffectWindow *kwindow, int mask, con
 #elif QT_VERSION_MAJOR >= 6
     OffscreenEffect::drawWindow(renderTarget, viewport, kwindow, mask, region, data);
 #else
-    OffscreenEffect::drawWindow(kwindow, mask, region, data);
+OffscreenEffect::drawWindow(kwindow, mask, region, data);
 #endif
     // Unbind the shader after drawing.
     m_shaderManager.Unbind();

--- a/src/Shader.cpp
+++ b/src/Shader.cpp
@@ -7,6 +7,7 @@
 #include "Window.h"
 #include "WindowConfig.h"
 #if QT_VERSION_MAJOR >= 6
+#include <core/pixelgrid.h>
 #include <effect/effect.h>
 #include <effect/effectwindow.h>
 #include <opengl/glutils.h>
@@ -99,8 +100,15 @@ void ShapeCorners::Shader::Bind(const Window &window, const double scale) const
     }
 
     // Calculate scaled geometries
+#if KWIN_EFFECT_API_VERSION >= 237 && KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 3, 4)
+    // KWin from 6.3.4 onwards snaps the offscreen texture's geometry to the device pixel grid,
+    // so the uniforms have to be derived the same way. KWin X11 does not snap.
+    const auto frameGeometry    = KWin::snapToPixels(window.w->frameGeometry(), scale) * scale;
+    const auto expandedGeometry = KWin::snapToPixels(window.w->expandedGeometry(), scale) * scale;
+#else
     const auto frameGeometry    = window.w->frameGeometry() * scale;
     const auto expandedGeometry = window.w->expandedGeometry() * scale;
+#endif
     // Calculate the offset between expanded and frame geometry
     const auto frameOffset = QVector2D(frameGeometry.topLeft() - expandedGeometry.topLeft());
     // Clamp the shadow size to the maximum allowed

--- a/src/Shader.h
+++ b/src/Shader.h
@@ -45,8 +45,16 @@ namespace ShapeCorners
          * \brief This function assigns the required variables to the shader.
          *        Then it pushes the shader to the stack of rendering.
          * \note  This needs to be called before each window is rendered.
+         * \note  Every geometry uniform describes the offscreen texture that the shader samples, so
+         *        all of them have to be derived exactly as KWin derives that texture. From KWin
+         *        6.3.4 onwards that means snapping the logical geometry onto the device pixel grid
+         *        first: raw geometry leaves the window frame up to a device pixel off inside the
+         *        texture, by an amount that varies with the window's sub-pixel position, which drags
+         *        the outline onto the window's own content as it moves on a fractionally scaled
+         *        screen. KWin X11 keeps the older effect API and does not snap.
          * \param window The window that the effect will be rendering on
-         * \param scale The scale of the screen
+         * \param scale The scale of the screen the window belongs to,
+         *        which is the scale KWin renders the offscreen texture at
          */
         void Bind(const Window &window, double scale) const;
 


### PR DESCRIPTION
This PR changes two items:

- KWin 6.3.4 snaps `expandedGeometry` and `frameGeometry` onto the device pixel grid before it sizes and positions the offscreen texture (https://github.com/KDE/kwin/commit/1d07d040a3bc). Deriving `windowSize`, `windowExpandedSize` and `windowTopLeft` from the raw geometry left the frame up to a device pixel off inside that texture, by an amount that varies with the window's sub-pixel position, so the outline crept onto the window's own content as the window moved on a fractional scale.

- KWin renders that texture at `window->screen()->scale()`, so `drawWindow` passes that instead of `viewport.scale();` the two differ while a window straddles two screens with different scales.

This may fix #468 & #343