### PR TITLE
Fix inverted texture coordinates on KWin 6.7.90

### DIFF
--- a/src/Shader.cpp
+++ b/src/Shader.cpp
@@ -27,6 +27,20 @@ namespace
     {
         return {static_cast<float>(size.width()), static_cast<float>(size.height())};
     }
+
+    /**
+     * @brief Whether the offscreen texture's coordinates run top-down.
+     *
+     * KWin 6.7.90 backs the offscreen texture with an EglSwapchain instead of a plain GL texture.
+     * Its dmabuf-imported texture carries an `OutputTransform::FlipY`, which cancels the y flip
+     * KWin bakes into the texture matrix, so `texcoord0.y` grows downward from the top edge rather
+     * than upward from the bottom edge. KWin X11 keeps the older effect API and the plain texture.
+     */
+#if KWIN_EFFECT_API_VERSION >= 237 && KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 7, 90)
+    constexpr bool kYInverted = true;
+#else
+    constexpr bool kYInverted = false;
+#endif
 } // namespace
 
 ShapeCorners::Shader::Shader()
@@ -62,6 +76,7 @@ ShapeCorners::Shader::Shader()
     m_shader_windowSize             = m_shader->uniformLocation("windowSize");
     m_shader_windowExpandedSize     = m_shader->uniformLocation("windowExpandedSize");
     m_shader_windowTopLeft          = m_shader->uniformLocation("windowTopLeft");
+    m_shader_yInverted              = m_shader->uniformLocation("yInverted");
     m_shader_usesNativeShadows      = m_shader->uniformLocation("usesNativeShadows");
     m_shader_shadowColor            = m_shader->uniformLocation("shadowColor");
     m_shader_shadowSize             = m_shader->uniformLocation("shadowSize");
@@ -120,6 +135,7 @@ void ShapeCorners::Shader::Bind(const Window &window, const double scale) const
     m_shader->setUniform(m_shader_windowSize, toVector2D(frameGeometry.size()));
     m_shader->setUniform(m_shader_windowExpandedSize, toVector2D(expandedGeometry.size()));
     m_shader->setUniform(m_shader_windowTopLeft, frameOffset);
+    m_shader->setUniform(m_shader_yInverted, static_cast<int>(kYInverted));
     m_shader->setUniform(m_shader_usesNativeShadows, static_cast<int>(Config::useNativeDecorationShadows()));
     m_shader->setUniform(m_shader_useSquircleShape, static_cast<int>(Config::useSquircleShape()));
     m_shader->setUniform(m_shader_squircleBlend, static_cast<float>(Config::squircleness()));

--- a/src/Shader.h
+++ b/src/Shader.h
@@ -98,6 +98,13 @@ namespace ShapeCorners
         int m_shader_windowTopLeft = 0;
 
         /**
+         * \brief Reference to `uniform bool yInverted;`
+         *        Whether `texcoord0.y` grows downward from the top edge of the offscreen texture
+         *        rather than upward from its bottom edge.
+         */
+        int m_shader_yInverted = 0;
+
+        /**
          * \brief Reference to `uniform float radius;`
          *        Containing the corner radius in pixels specified in settings.
          */

--- a/src/shaders/variables.glsl
+++ b/src/shaders/variables.glsl
@@ -20,15 +20,18 @@ uniform vec4  outerOutlineColor2;     // The RGBA of the outer outline's second 
 uniform float outerOutlineAngle;      // The outer outline gradient angle in degrees.
 uniform float outerOutlineThickness;  // The thickness of the outer outline in pixels specified in settings.
 
+uniform bool yInverted; /* Whether `texcoord0.y` grows downward from the top edge of the offscreen
+                         * texture rather than upward from its bottom edge. */
+
 vec2 tex_to_pixel(vec2 texcoord)
 {
-    return vec2(texcoord.x * windowExpandedSize.x - windowTopLeft.x,
-                (1.0 - texcoord.y) * windowExpandedSize.y - windowTopLeft.y);
+    float y = yInverted ? texcoord.y : 1.0 - texcoord.y;
+    return vec2(texcoord.x * windowExpandedSize.x - windowTopLeft.x, y * windowExpandedSize.y - windowTopLeft.y);
 }
 vec2 pixel_to_tex(vec2 pixelcoord)
 {
-    return vec2((pixelcoord.x + windowTopLeft.x) / windowExpandedSize.x,
-                1.0 - (pixelcoord.y + windowTopLeft.y) / windowExpandedSize.y);
+    float y = (pixelcoord.y + windowTopLeft.y) / windowExpandedSize.y;
+    return vec2((pixelcoord.x + windowTopLeft.x) / windowExpandedSize.x, yInverted ? y : 1.0 - y);
 }
 bool hasExpandedSize() { return windowTopLeft.x >= 1.0 && windowTopLeft.y >= 1.0; }
 bool hasPrimaryOutline() { return outlineColor1.a > 0.0 && outlineThickness > 0.0; }


### PR DESCRIPTION
Fixes #529.

## Root cause

KWin 6.7.90 changed `OffscreenEffect` to back the offscreen texture with an `EglSwapchain` instead of `GLTexture::allocate()` ([kwin!514379a3f9](https://invent.kde.org/plasma/kwin/-/commit/514379a3f9), the only tag containing it is `v6.7.90`).

The two paths disagree on the texture's content transform:

- `GLTexture::allocate()` constructs with `OutputTransform{}` (Normal), so `matrix(NormalizedCoordinates)` maps `y -> 1 - y`.
- The swapchain slot imports its dmabuf through `EGLImageTexture`, which is constructed with `OutputTransform::FlipY`. `FlipY` cancels the `scale(1, -1)` that `GLTexturePrivate::updateMatrix()` bakes in, so the normalized matrix becomes **identity**.

`OffscreenData::paint()` runs the quad's texture coordinates through that matrix, and `RenderGeometry::postProcessTextureCoordinates()` skips an identity matrix outright. The quad is authored top-left `(0,0)` / bottom-left `(0,1)`, so `texcoord0.y` now grows downward from the top of the texture, where it used to grow upward from the bottom.

`tex_to_pixel()` hardcoded the old bottom-up convention (`1.0 - texcoord.y`), so the mask came out mirrored vertically inside the texture. With an asymmetric drop shadow (top margin `t`, bottom margin `b`) the mask lands at `[b, b + frameHeight]` instead of `[t, t + frameHeight]` — shifted down by `b - t`, with its rounded "top" corners sitting at the very bottom edge of the shadow. That is exactly the reported symptom: square window corners, and a rounded outline visible below the window's bottom edge.

## Fix

`tex_to_pixel()` and `pixel_to_tex()` take the direction from a new `yInverted` uniform instead of hardcoding it. The value is a compile-time constant gated on `KWIN_EFFECT_API_VERSION >= 237 && KWIN_PLUGIN_VERSION_NUM >= QT_VERSION_CHECK(6, 7, 90)` — the same gating convention `Shader.cpp` already uses to separate Wayland KWin from KWin X11, which keeps the older effect API and the plain `GLTexture::allocate()` path.
